### PR TITLE
fix: correct algorithm implementation bugs in Wei, Zafeiris, and CK m…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,124 @@
+# Spring RMT — Claude Code Guide
+
+## Project Overview
+
+Spring RMT is a Maven monorepo that automatically detects design-pattern refactoring opportunities in Java projects, applies the transformations, and measures the resulting code-quality change using CK metrics.
+
+## Module Structure
+
+| Module | Artifact ID | Purpose |
+|---|---|---|
+| `config-starter` | `config-starter` | Shared library: domain models, S3/Redis/SQS configuration, JavaParser setup, queue definitions |
+| `project-sync-bff` | `projectsyncbff` | Entry point: Thymeleaf/HTMX UI and REST API; accepts ZIP uploads, drives the pipeline |
+| `detection-and-refactoring` | `detectionandrefactoring` | Consumes `detect-pattern` queue; parses Java ASTs, detects candidates, applies refactorings |
+| `metrics-calculator` | `metricscalculator` | Consumes `measure-pattern` queue; runs CK metrics on original and refactored code |
+
+`config-starter` is a library, not a runnable service. The other three are Spring Boot applications.
+
+## Build & Run Commands
+
+```bash
+# Build everything (from repo root)
+mvn clean install
+
+# Build a single module
+mvn clean install -pl config-starter
+mvn clean package -pl detection-and-refactoring
+
+# Run a service locally (from repo root)
+mvn spring-boot:run -pl project-sync-bff
+mvn spring-boot:run -pl detection-and-refactoring
+mvn spring-boot:run -pl metrics-calculator
+
+# Run all tests
+mvn test
+
+# Run tests for one module only
+mvn test -pl detection-and-refactoring
+```
+
+## One-command Setup
+
+```bash
+./rmt.sh          # build + docker images + full local environment (default)
+./rmt.sh dev      # build + start infra only, then run services with mvn spring-boot:run
+./rmt.sh build    # Maven build only
+./rmt.sh infra    # LocalStack + Redis + Terraform only
+```
+
+Windows: `.\rmt.ps1 [command]` — same subcommands.
+
+Before first run, initialise Terraform once: `tflocal -chdir=infra init`
+
+## Tech Stack
+
+- **Java 25** (source/target set to 21 in pom.xml)
+- **Spring Boot 4.0.4** / Spring Framework 7
+- **Spring Cloud 2025.1.1 (Oakwood)** / **Spring Cloud AWS 4.0.0**
+- **Rqueue 4.0.0-SNAP-RELEASE** for Redis-backed queues
+- **Lombok 1.18.38** — first version with Java 25 annotation-processor support
+- **JavaParser 3.26.1** for AST manipulation
+- **CK 0.7.0** (mauricioaniche) for code metrics
+
+## Code Conventions
+
+### General
+- Lombok `@Builder` / `@SuperBuilder` / `@RequiredArgsConstructor` are used extensively — do not add manual constructors or boilerplate.
+- Spring beans are wired by constructor (via `@RequiredArgsConstructor`), not field injection.
+- `var` is used for local variables throughout; follow the same style.
+- No additional comments or Javadoc on existing code unless logic is genuinely non-obvious.
+
+### Testing
+- Tests use **JUnit 5** + **Mockito** (subclass mock maker — see `mockito-extensions/org.mockito.plugins.MockMaker`).
+- `@MockitoBean` (not `@MockBean`) for Spring slice tests.
+- `@WebMvcTest` is from `org.springframework.boot.webmvc.test.autoconfigure` (Boot 4 package).
+- `MockPart` is used instead of `MockMultipartFile.file()` (removed in Spring Framework 7).
+- Fixtures for the Wei and Zafeiris tests live in `detection-and-refactoring/src/test/java/fixtures/`.
+
+### Domain Models (config-starter)
+- `BaseProject` — tracks pipeline status with a `LinkedHashSet<ProjectStatus>` (order matters).
+- `RefactorFiles` — a mutable builder class (not a record) that accumulates files and candidates during a refactoring run.
+- `JavaFile` — wraps raw source + parsed `CompilationUnit`; `getParsed()` returns `Object` cast to `CompilationUnit`.
+
+## Detection Algorithm Structure
+
+```
+DetectionMethodsManagerWei  (Strategy + Factory Method — Wei et al. 2014)
+  └─ WeiEtAl2014
+       ├─ WeiEtAl2014StrategyVerifier   → WeiEtAl2014StrategyCandidate
+       ├─ WeiEtAl2014FactoryVerifier    → WeiEtAl2014FactoryCandidate
+       ├─ WeiEtAl2014StrategyExecutor
+       └─ WeiEtAl2014FactoryExecutor
+
+DetectionMethodsManagerZaiferis  (Template Method — Zafeiris et al. 2016)
+  └─ ZafeirisEtAl2016
+       ├─ ZafeirisEtAl2016Verifier
+       │    ├─ SuperInvocationPreconditions
+       │    ├─ ExtractMethodPreconditions
+       │    └─ SiblingPreconditions
+       └─ ZafeirisEtAl2016Executor
+            └─ FragmentsSplitter
+```
+
+### Key algorithm rules (already enforced in code)
+- Wei verifier: candidate methods must have ≥ 1 parameter and a non-void return type. The parameter used in the if-condition is the **discriminator** — identified at runtime, not assumed to be at index 0.
+- Zafeiris verifier: excludes `toString`, `equals`, `hashCode`, `clone`, `finalize`, `compareTo` and any getter/setter. Requires exactly 1 non-nested `super()` call per method. Sibling classes are grouped by shared parent type.
+- CK metrics are averaged across all classes (not summed) before comparison.
+
+## Infrastructure (Local)
+
+| Service | Port |
+|---|---|
+| project-sync-bff | 8080 |
+| detection-and-refactoring | 8081 |
+| metrics-calculator | 8083 |
+| LocalStack (AWS emulation) | 4566 |
+| Redis | 6379 |
+
+Terraform (`infra/main.tf`) provisions the S3 buckets and SQS queues in LocalStack.
+
+## Git Conventions
+
+- Main branch: `main`. Working branch: `develop`. Features branch from `develop`.
+- Commit messages follow Conventional Commits: `fix:`, `feat:`, `refactor:`, `chore:`, `test:`, `docs:`.
+- Do not include `Co-Authored-By` trailers in commits.

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/weiL/executors/WeiEtAl2014FactoryExecutor.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/weiL/executors/WeiEtAl2014FactoryExecutor.java
@@ -22,8 +22,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
+import com.github.javaparser.ast.expr.BinaryExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 @Component
 @RequiredArgsConstructor
@@ -147,7 +151,10 @@ public class WeiEtAl2014FactoryExecutor implements WeiEtAl2014Executor {
         classDclr.setAbstract(true);
         candidateMethod.setBody(null);
         candidateMethod.setAbstract(true);
-        candidateMethod.getParameter(0).remove();
+        final var discriminatorIndex = findDiscriminatorParameterIndex(candidate.getMethodDcl(), candidate.getIfStatements());
+        if (discriminatorIndex < candidateMethod.getParameters().size()) {
+            candidateMethod.getParameter(discriminatorIndex).remove();
+        }
     }
 
     private CompilationUnit updateBaseCompilationUnit(Collection<CompilationUnit> classes,
@@ -157,6 +164,34 @@ public class WeiEtAl2014FactoryExecutor implements WeiEtAl2014Executor {
                         Optional.of(candidate.getPackageDeclaration())))
                 .findFirst()
                 .orElseThrow(IllegalArgumentException::new);
+    }
+
+    private int findDiscriminatorParameterIndex(MethodDeclaration method, Collection<IfStmt> ifStatements) {
+        final var params = method.getParameters();
+        if (params.isEmpty()) return 0;
+        return ifStatements.stream()
+                .findFirst()
+                .map(ifStmt -> {
+                    final var binary = ifStmt.getChildNodes().stream()
+                            .filter(BinaryExpr.class::isInstance).map(BinaryExpr.class::cast).findFirst();
+                    final var methodCall = ifStmt.getChildNodes().stream()
+                            .filter(MethodCallExpr.class::isInstance).map(MethodCallExpr.class::cast).findFirst();
+                    return IntStream.range(0, params.size())
+                            .filter(i -> isNameInExpression(params.get(i).getNameAsString(), binary, methodCall))
+                            .findFirst()
+                            .orElse(0);
+                })
+                .orElse(0);
+    }
+
+    private boolean isNameInExpression(String name, Optional<BinaryExpr> binary, Optional<MethodCallExpr> methodCall) {
+        if (binary.isPresent()) {
+            return binary.get().stream().anyMatch(n ->
+                    AstHandler.getNameExpr(n).map(NameExpr::getNameAsString).map(name::equals).orElse(false));
+        }
+        return methodCall.map(mc -> mc.stream().anyMatch(n ->
+                AstHandler.getNameExpr(n).map(NameExpr::getNameAsString).map(name::equals).orElse(false)))
+                .orElse(false);
     }
 
     @Override

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/weiL/executors/WeiEtAl2014StrategyExecutor.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/weiL/executors/WeiEtAl2014StrategyExecutor.java
@@ -20,7 +20,7 @@ import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.IfStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
-import com.github.javaparser.ast.type.TypeParameter;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
@@ -28,6 +28,7 @@ import org.springframework.util.Assert;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Component
 @RequiredArgsConstructor
@@ -140,7 +141,8 @@ public class WeiEtAl2014StrategyExecutor implements WeiEtAl2014Executor {
         returnStmt.setExpression(methodCall);
         block.addStatement(returnStmt);
         candidateMethod.setBody(block);
-        candidateMethod.setParameter(0, new Parameter(new TypeParameter(createdStrategy.getNameAsString()), "strategy"));
+        final var discriminatorIndex = findDiscriminatorParameterIndex(candidate.getMethodDcl(), candidate.getIfStatements());
+        candidateMethod.setParameter(discriminatorIndex, new Parameter(new ClassOrInterfaceType(createdStrategy.getNameAsString()), "strategy"));
     }
 
     private FieldAccessExpr parseVariableToFieldAccess(VariableDeclarator var) {
@@ -158,6 +160,34 @@ public class WeiEtAl2014StrategyExecutor implements WeiEtAl2014Executor {
                 .findFirst()
                 .orElseThrow(IllegalArgumentException::new);
 
+    }
+
+    private int findDiscriminatorParameterIndex(MethodDeclaration method, Collection<IfStmt> ifStatements) {
+        final var params = method.getParameters();
+        if (params.isEmpty()) return 0;
+        return ifStatements.stream()
+                .findFirst()
+                .map(ifStmt -> {
+                    final var binary = ifStmt.getChildNodes().stream()
+                            .filter(BinaryExpr.class::isInstance).map(BinaryExpr.class::cast).findFirst();
+                    final var methodCall = ifStmt.getChildNodes().stream()
+                            .filter(MethodCallExpr.class::isInstance).map(MethodCallExpr.class::cast).findFirst();
+                    return IntStream.range(0, params.size())
+                            .filter(i -> isNameInExpression(params.get(i).getNameAsString(), binary, methodCall))
+                            .findFirst()
+                            .orElse(0);
+                })
+                .orElse(0);
+    }
+
+    private boolean isNameInExpression(String name, Optional<BinaryExpr> binary, Optional<MethodCallExpr> methodCall) {
+        if (binary.isPresent()) {
+            return binary.get().stream().anyMatch(n ->
+                    AstHandler.getNameExpr(n).map(NameExpr::getNameAsString).map(name::equals).orElse(false));
+        }
+        return methodCall.map(mc -> mc.stream().anyMatch(n ->
+                AstHandler.getNameExpr(n).map(NameExpr::getNameAsString).map(name::equals).orElse(false)))
+                .orElse(false);
     }
 
     @Override

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/weiL/verifiers/WeiEtAl2014Verifier.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/weiL/verifiers/WeiEtAl2014Verifier.java
@@ -40,7 +40,6 @@ public abstract class WeiEtAl2014Verifier implements RefactoringCandidatesVerifi
     private boolean isMethodInvalid(MethodDeclaration method) {
         return method.getParameters() == null
                 || method.getParameters().isEmpty()
-                || method.getParameters().size() > 1
                 || (method.getType() instanceof VoidType);
     }
 

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/preconditions/ExtractMethodPreconditions.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/preconditions/ExtractMethodPreconditions.java
@@ -30,7 +30,7 @@ public class ExtractMethodPreconditions {
     }
 
     private boolean fragmentsHaveMinSize(FragmentsSplitter fragmentsSplitter) {
-        return fragmentsSplitter.getBeforeFragment().size() > 2 || fragmentsSplitter.getAfterFragment().size() > 2;
+        return !fragmentsSplitter.getBeforeFragment().isEmpty() || !fragmentsSplitter.getAfterFragment().isEmpty();
     }
 
     private boolean methodsValuesMatch(MethodDeclaration m1, MethodDeclaration m2) {

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/preconditions/SiblingPreconditions.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/preconditions/SiblingPreconditions.java
@@ -1,7 +1,6 @@
 package br.com.magnus.detectionandrefactoring.refactor.methods.zaiferisVE.preconditions;
 
 import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AstHandler;
-import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.exceptions.SimpleNameException;
 import br.com.magnus.detectionandrefactoring.refactor.methods.zaiferisVE.ZafeirisEtAl2016Candidate;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.expr.MethodCallExpr;
@@ -108,27 +107,15 @@ public class SiblingPreconditions {
         final Set<ClassOrInterfaceDeclaration> declarations = new HashSet<>();
 
         boolean belongs(ClassOrInterfaceDeclaration dclr) {
-            return declarations.contains(dclr) && this.isChild(dclr) && this.isParent(dclr);
-        }
-
-        private boolean isChild(ClassOrInterfaceDeclaration dclr) {
-            final Optional<ClassOrInterfaceType> parent = AstHandler.getParentType(dclr);
-            return parent.filter(classOrInterfaceType -> declarations.stream()
-                            .map(AstHandler::getSimpleName)
-                            .flatMap(Optional::stream)
-                            .anyMatch(n -> n.equals(AstHandler.getSimpleName(classOrInterfaceType).orElseThrow(SimpleNameException::new))))
-                    .isPresent();
-        }
-
-        private boolean isParent(ClassOrInterfaceDeclaration dclr) {
-            return this.declarations.stream()
+            final Optional<ClassOrInterfaceType> dclrParent = AstHandler.getParentType(dclr);
+            if (dclrParent.isEmpty()) {
+                return false;
+            }
+            return declarations.stream()
                     .map(AstHandler::getParentType)
                     .flatMap(Optional::stream)
-                    .map(AstHandler::getSimpleName)
-                    .flatMap(Optional::stream)
-                    .anyMatch(n -> n.equals(AstHandler.getSimpleName(dclr).orElseThrow(SimpleNameException::new)));
+                    .anyMatch(parent -> parent.asString().equals(dclrParent.get().asString()));
         }
-
     }
 
 }

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/preconditions/SuperInvocationPreconditions.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/preconditions/SuperInvocationPreconditions.java
@@ -25,7 +25,7 @@ public class SuperInvocationPreconditions {
                 .map(SimpleName::asString)
                 .orElse("");
 
-        return superCalls.size() != 1 || invalidMethodNames.contains(name) && (name.startsWith(GET) || name.startsWith(SET));
+        return superCalls.size() != 1 || invalidMethodNames.contains(name) || name.startsWith(GET) || name.startsWith(SET);
     }
 
     public boolean isOverriddenMethodValid(MethodDeclaration overriddenMethod, MethodDeclaration method) {
@@ -45,7 +45,7 @@ public class SuperInvocationPreconditions {
             return true;
         } else if (overriddenMethod.getModifiers().contains(Modifier.protectedModifier())) {
             return method.getModifiers().stream()
-                    .anyMatch(m -> m.equals(Modifier.protectedModifier()) || m.equals(Modifier.privateModifier()));
+                    .anyMatch(m -> m.equals(Modifier.protectedModifier()) || m.equals(Modifier.publicModifier()));
         } else if (overriddenMethod.getModifiers().contains(Modifier.privateModifier())) {
             return method.getModifiers().stream().anyMatch(m -> m.equals(Modifier.privateModifier()));
         }

--- a/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/zaiferisVE/preconditions/ExtractMethodPreconditionsTest.java
+++ b/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/zaiferisVE/preconditions/ExtractMethodPreconditionsTest.java
@@ -164,11 +164,11 @@ class ExtractMethodPreconditionsTest {
     }
 
     @Test
-    @DisplayName("Should return false when gragments do no have min size")
-    public void shouldReturnFalseWhenGragmentsDoNoHaveMinSize() {
+    @DisplayName("Should return false when method body contains only the super call with no before or after fragments")
+    public void shouldReturnFalseWhenMethodBodyContainsOnlyTheSuperCall() {
         var overriddenMethod = new MethodDeclaration(
                 NodeList.nodeList(Modifier.publicModifier()),
-               "overridenMethod",
+                "overridenMethod",
                 new VoidType(),
                 NodeList.nodeList()
         );
@@ -182,8 +182,7 @@ class ExtractMethodPreconditionsTest {
                 NodeList.nodeList(),
                 NodeList.nodeList(),
                 new BlockStmt(NodeList.nodeList(
-                        new ExpressionStmt(new VariableDeclarationExpr(new PrimitiveType(), "primitive")),
-                        new ExpressionStmt(new MethodCallExpr("super", new NameExpr("primitive"), superExpr))
+                        new ExpressionStmt(new MethodCallExpr("super", superExpr))
                 )));
 
         var result = this.extractMethodPreconditions.isValid(overriddenMethod, method);

--- a/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/zaiferisVE/preconditions/SuperInvocationPreconditionsTest.java
+++ b/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/zaiferisVE/preconditions/SuperInvocationPreconditionsTest.java
@@ -82,33 +82,33 @@ class SuperInvocationPreconditionsTest {
     }
 
     @Test
-    @DisplayName("Should return false for one super call and a method starting with get")
-    public void shouldReturnFalseForOneSuperCallAndAMethodStartingWithGet() {
+    @DisplayName("Should return true for one super call and a method starting with get")
+    public void shouldReturnTrueForOneSuperCallAndAMethodStartingWithGet() {
         var method = new MethodDeclaration(NodeList.nodeList(Modifier.publicModifier()), new VoidType(), "getTest");
 
         var result = superInvocationPreconditions.violatesAmountOfSuperCallsOrName(method, List.of(new SuperExpr()));
 
-        assertFalse(result);
+        assertTrue(result);
     }
 
     @Test
-    @DisplayName("Should return false for one super call and a method starting with set")
-    public void shouldReturnFalseForOneSuperCallAndAMethodStartingWithSet() {
+    @DisplayName("Should return true for one super call and a method starting with set")
+    public void shouldReturnTrueForOneSuperCallAndAMethodStartingWithSet() {
         var method = new MethodDeclaration(NodeList.nodeList(Modifier.publicModifier()), new VoidType(), "setTest");
 
         var result = superInvocationPreconditions.violatesAmountOfSuperCallsOrName(method, List.of(new SuperExpr()));
 
-        assertFalse(result);
+        assertTrue(result);
     }
 
     @Test
-    @DisplayName("Should return false for one super call and a method starting with invalid name")
-    public void shouldReturnFalseForOneSuperCallAndAMethodStartingWithInvalidName() {
+    @DisplayName("Should return true for one super call and a method with invalid name")
+    public void shouldReturnTrueForOneSuperCallAndAMethodWithInvalidName() {
         var method = new MethodDeclaration(NodeList.nodeList(Modifier.publicModifier()), new VoidType(), "toString");
 
         var result = superInvocationPreconditions.violatesAmountOfSuperCallsOrName(method, List.of(new SuperExpr()));
 
-        assertFalse(result);
+        assertTrue(result);
     }
 
     @Test

--- a/metrics-calculator/src/main/java/br/com/magnus/metricscalculator/metrics/CKNotifierImpl.java
+++ b/metrics-calculator/src/main/java/br/com/magnus/metricscalculator/metrics/CKNotifierImpl.java
@@ -25,16 +25,16 @@ public class CKNotifierImpl implements CKNotifier, MetricsResolver {
 
     @Override
     public int getDepthOfInheritanceTree() {
-        return results.values().stream().mapToInt(CKClassResult::getDit).sum();
+        return (int) Math.round(results.values().stream().mapToInt(CKClassResult::getDit).average().orElse(0));
     }
 
     @Override
     public int getCyclomaticComplexity() {
-        return results.values().stream().mapToInt(CKClassResult::getWmc).sum();
+        return (int) Math.round(results.values().stream().mapToInt(CKClassResult::getWmc).average().orElse(0));
     }
 
     @Override
     public int getLinesOfCode() {
-        return results.values().stream().mapToInt(CKClassResult::getLoc).sum();
+        return (int) Math.round(results.values().stream().mapToInt(CKClassResult::getLoc).average().orElse(0));
     }
 }


### PR DESCRIPTION
…etric modules

Wei et al. 2014:
- Remove overly strict single-parameter restriction from WeiEtAl2014Verifier so methods with multiple parameters are now valid candidates, matching the paper
- Replace hardcoded parameter index 0 with discriminator-aware lookup in both WeiEtAl2014StrategyExecutor and WeiEtAl2014FactoryExecutor; the discriminator is the parameter used in the if-condition, not necessarily the first one
- Fix WeiEtAl2014StrategyExecutor: replace TypeParameter (generic type variable) with ClassOrInterfaceType for the injected Strategy parameter

Zafeiris et al. 2016:
- Fix operator-precedence bug in SuperInvocationPreconditions: toString/equals/ hashCode/clone/finalize/compareTo and get*/set* methods were never excluded because && binds tighter than ||; corrected to use || throughout
- Fix SuperInvocationPreconditions: protected overridden method incorrectly allowed a private overriding method (impossible in Java); corrected to require protected or public
- Fix SiblingPreconditions.Hierarchy.belongs: the declarations.contains(dclr) guard meant no new class could ever join a hierarchy, making the sibling deduplication a no-op; rewritten to group classes that share the same parent type (siblings), and removed the now-dead isChild/isParent helpers
- Relax ExtractMethodPreconditions.fragmentsHaveMinSize from >2 to >0: the paper requires non-empty before or after fragments, not at least 3 AST nodes

Aniche 2015 CK metrics:
- CKNotifierImpl aggregated per-class metrics with sum(), which grows with the number of classes produced by refactoring; changed to average() so comparisons between original and refactored are scale-independent

Tests updated to reflect correct behaviour for the three SuperInvocationPreconditions cases and the ExtractMethodPreconditions min-size case.