### PR TITLE
fix: align Wei and Zafeiris verifiers with the papers

### DIFF
--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/dataExtractions/ast/AstHandler.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/dataExtractions/ast/AstHandler.java
@@ -282,8 +282,22 @@ public class AstHandler {
         if (node == null) {
             throw new NullNodeException();
         }
-        if (node instanceof NodeWithCondition || node instanceof TryStmt || node instanceof CatchClause) {
+        if (node instanceof NodeWithCondition || node instanceof CatchClause) {
             return false;
+        }
+
+        if (node instanceof TryStmt tryStmt) {
+            final var hasSuperInCatch = tryStmt.getCatchClauses().stream()
+                    .anyMatch(AstHandler::nodeHasSuperCall);
+            final var hasSuperInFinally = tryStmt.getFinallyBlock()
+                    .map(AstHandler::nodeHasSuperCall)
+                    .orElse(false);
+
+            if (hasSuperInCatch || hasSuperInFinally) {
+                return false;
+            }
+
+            return childHasDirectSuperCall(tryStmt.getTryBlock());
         }
 
         if (node instanceof MethodCallExpr && ((MethodCallExpr) node).getArguments() != null) {
@@ -306,6 +320,10 @@ public class AstHandler {
         }
 
         return node.getChildNodes().stream().anyMatch(AstHandler::childHasDirectSuperCall);
+    }
+
+    private static boolean nodeHasSuperCall(Node node) {
+        return !getSuperCalls(node).isEmpty();
     }
 
     public static boolean nodeHasReturnStatement(Node node) {

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/weiL/verifiers/WeiEtAl2014Verifier.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/weiL/verifiers/WeiEtAl2014Verifier.java
@@ -40,6 +40,7 @@ public abstract class WeiEtAl2014Verifier implements RefactoringCandidatesVerifi
     private boolean isMethodInvalid(MethodDeclaration method) {
         return method.getParameters() == null
                 || method.getParameters().isEmpty()
+                || method.getParameters().size() > 1
                 || (method.getType() instanceof VoidType);
     }
 

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/weiL/verifiers/WeiEtAl2014Verifier.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/weiL/verifiers/WeiEtAl2014Verifier.java
@@ -7,6 +7,7 @@ import br.com.magnus.detectionandrefactoring.refactor.methods.weiL.RefactoringCa
 import br.com.magnus.detectionandrefactoring.refactor.methods.weiL.WeiEtAl2014Candidate;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.IfStmt;
+import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.ast.type.VoidType;
 import org.springframework.util.Assert;
 
@@ -51,12 +52,55 @@ public abstract class WeiEtAl2014Verifier implements RefactoringCandidatesVerifi
         }
 
         final var ifStatements = AstHandler.getIfStatements(method);
+        if (this.hasUnsupportedNestedIfStatements(method)) {
+            return Optional.empty();
+        }
 
         if (!this.areIfStmtsValid(javaFiles, file,method, ifStatements)) {
             return Optional.empty();
         }
 
         return Optional.of(this.createCandidate(file, method, ifStatements));
+    }
+
+    private boolean hasUnsupportedNestedIfStatements(MethodDeclaration method) {
+        return method.getBody()
+                .map(body -> body.getStatements().stream()
+                        .filter(IfStmt.class::isInstance)
+                        .map(IfStmt.class::cast)
+                        .anyMatch(this::containsNestedIfOutsideElseIfChain))
+                .orElse(false);
+    }
+
+    private boolean containsNestedIfOutsideElseIfChain(IfStmt ifStmt) {
+        if (this.containsAnyIf(ifStmt.getThenStmt())) {
+            return true;
+        }
+
+        final var elseStmt = ifStmt.getElseStmt();
+        if (elseStmt.isEmpty()) {
+            return false;
+        }
+
+        final var statement = elseStmt.get();
+        if (statement instanceof IfStmt elseIf) {
+            return this.containsNestedIfOutsideElseIfChain(elseIf);
+        }
+
+        return this.containsAnyIf(statement);
+    }
+
+    private boolean containsAnyIf(Statement statement) {
+        return statement.getChildNodes().stream()
+                .anyMatch(node -> node instanceof IfStmt || node.getChildNodes().stream()
+                        .anyMatch(child -> child instanceof IfStmt || this.nodeContainsIf(child)));
+    }
+
+    private boolean nodeContainsIf(com.github.javaparser.ast.Node node) {
+        if (node instanceof IfStmt) {
+            return true;
+        }
+        return node.getChildNodes().stream().anyMatch(this::nodeContainsIf);
     }
 
     protected abstract WeiEtAl2014Candidate createCandidate(JavaFile file, MethodDeclaration method, Collection<IfStmt> ifStatements);

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/preconditions/ExtractMethodPreconditions.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/preconditions/ExtractMethodPreconditions.java
@@ -3,9 +3,13 @@ package br.com.magnus.detectionandrefactoring.refactor.methods.zaiferisVE.precon
 import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AstHandler;
 import br.com.magnus.detectionandrefactoring.refactor.methods.zaiferisVE.FragmentsSplitter;
 import com.github.javaparser.ast.DataKey;
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithCondition;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.Statement;
+import com.github.javaparser.ast.stmt.TryStmt;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -18,6 +22,10 @@ import java.util.Optional;
 public class ExtractMethodPreconditions {
 
     public boolean isValid(MethodDeclaration overriddenMethod, MethodDeclaration m) {
+        return this.isValidIgnoringMinSize(overriddenMethod, m) && this.hasMinimumFragmentsSize(m);
+    }
+
+    public boolean isValidIgnoringMinSize(MethodDeclaration overriddenMethod, MethodDeclaration m) {
         final var fragmentsSplitter = FragmentsSplitter.splitByMethod(m);
 
         return fragmentsSplitter.hasSpecificNode()
@@ -25,8 +33,12 @@ public class ExtractMethodPreconditions {
                 && this.beforeFragmentThrowsNoException(fragmentsSplitter)
                 && this.beforeFragmentHasNoReturn(fragmentsSplitter)
                 && !this.hasMultipleVariablesInBeforeFragmentsMethodCalls(fragmentsSplitter)
-                && this.methodsValuesMatch(overriddenMethod, m)
-                && this.fragmentsHaveMinSize(fragmentsSplitter);
+                && this.methodsValuesMatch(overriddenMethod, m);
+    }
+
+    public boolean hasMinimumFragmentsSize(MethodDeclaration method) {
+        final var fragmentsSplitter = FragmentsSplitter.splitByMethod(method);
+        return this.fragmentsHaveMinSize(fragmentsSplitter);
     }
 
     private boolean fragmentsHaveMinSize(FragmentsSplitter fragmentsSplitter) {
@@ -76,7 +88,54 @@ public class ExtractMethodPreconditions {
 
         final Optional<BlockStmt> blockStmt = AstHandler.getBlockStatement(m);
 
-        return blockStmt.filter(AstHandler::childHasDirectSuperCall).isPresent();
+        return blockStmt.filter(this::hasSuperAtTopLevelOrInTryOnly).isPresent();
+    }
+
+    private boolean hasSuperAtTopLevelOrInTryOnly(BlockStmt blockStmt) {
+        return blockStmt.getStatements()
+                .stream()
+                .anyMatch(this::isAllowedSuperStatement);
+    }
+
+    private boolean isAllowedSuperStatement(Statement statement) {
+        if (statement instanceof NodeWithCondition) {
+            return false;
+        }
+        return this.hasSuperInAllowedContext(statement);
+    }
+
+    private boolean hasSuperInAllowedContext(Node node) {
+        if (node == null) {
+            return false;
+        }
+
+        if (node instanceof NodeWithCondition) {
+            return false;
+        }
+
+        if (node instanceof TryStmt tryStmt) {
+            final var hasSuperInCatch = tryStmt.getCatchClauses().stream()
+                    .anyMatch(this::containsSuperAnywhere);
+            final var hasSuperInFinally = tryStmt.getFinallyBlock()
+                    .map(this::containsSuperAnywhere)
+                    .orElse(false);
+
+            if (hasSuperInCatch || hasSuperInFinally) {
+                return false;
+            }
+
+            return this.hasSuperInAllowedContext(tryStmt.getTryBlock());
+        }
+
+        if (AstHandler.getSuperCalls(node).stream().anyMatch(superExpr -> superExpr.equals(node))) {
+            return true;
+        }
+
+        return node.getChildNodes().stream().anyMatch(this::hasSuperInAllowedContext);
+    }
+
+    private boolean containsSuperAnywhere(Node node) {
+        return !AstHandler.getSuperCalls(node).isEmpty();
 
     }
 

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/preconditions/SiblingPreconditions.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/preconditions/SiblingPreconditions.java
@@ -1,6 +1,7 @@
 package br.com.magnus.detectionandrefactoring.refactor.methods.zaiferisVE.preconditions;
 
 import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AstHandler;
+import br.com.magnus.detectionandrefactoring.refactor.methods.zaiferisVE.FragmentsSplitter;
 import br.com.magnus.detectionandrefactoring.refactor.methods.zaiferisVE.ZafeirisEtAl2016Candidate;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
@@ -23,9 +24,21 @@ public class SiblingPreconditions {
             return false;
         }
 
+        if (this.allCandidatesHaveTrivialFragments(candidatesOfSameOverriddenMethod)) {
+            return true;
+        }
+
         return !beforeFragmentReturnEqual(candidatesWithVariables)
                 || !this.beforeReturnIsUsedInSuper(candidatesWithVariables)
                 || this.isAShortHierarchy(candidatesWithVariables);
+    }
+
+    private boolean allCandidatesHaveTrivialFragments(Collection<ZafeirisEtAl2016Candidate> candidates) {
+        return candidates.stream()
+                .map(ZafeirisEtAl2016Candidate::getOverridingMethod)
+                .map(FragmentsSplitter::splitByMethod)
+                .allMatch(fragments -> fragments.getBeforeFragment().size() < 2
+                        && fragments.getAfterFragment().size() < 2);
     }
 
     private boolean isAShortHierarchy(List<ZafeirisEtAl2016Candidate.CandidateWithVariables> candidatesWithVariables) {
@@ -47,7 +60,7 @@ public class SiblingPreconditions {
 
         boolean areEqual = true;
 
-        for (int i = 1; i < candidatesWithVariables.size() - 1; i++) {
+        for (int i = 0; i < candidatesWithVariables.size() - 1; i++) {
             if (candidatesWithVariables.get(i).variables().size() > 1) {
                 throw new IllegalStateException("Candidate with multiple variables found");
             } else if (candidatesWithVariables.get(i).variables().size() != candidatesWithVariables.get(i + 1).variables().size()) {

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/preconditions/SiblingPreconditions.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/preconditions/SiblingPreconditions.java
@@ -2,7 +2,6 @@ package br.com.magnus.detectionandrefactoring.refactor.methods.zaiferisVE.precon
 
 import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AstHandler;
 import br.com.magnus.detectionandrefactoring.refactor.methods.zaiferisVE.ZafeirisEtAl2016Candidate;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
@@ -20,32 +19,28 @@ public class SiblingPreconditions {
         final List<ZafeirisEtAl2016Candidate.CandidateWithVariables> candidatesWithVariables = candidatesOfSameOverriddenMethod.stream()
                 .map(ZafeirisEtAl2016Candidate::toCandidateWithVariables)
                 .collect(Collectors.toList());
+        if (candidatesWithVariables.size() < 2) {
+            return false;
+        }
 
         return !beforeFragmentReturnEqual(candidatesWithVariables)
-                && !this.beforeReturnIsUsedInSuper(candidatesWithVariables)
-                && this.isAShortHierarchy(candidatesWithVariables);
+                || !this.beforeReturnIsUsedInSuper(candidatesWithVariables)
+                || this.isAShortHierarchy(candidatesWithVariables);
     }
 
     private boolean isAShortHierarchy(List<ZafeirisEtAl2016Candidate.CandidateWithVariables> candidatesWithVariables) {
+        final var byParent = candidatesWithVariables.stream()
+                .map(c -> c.candidate().getClassDeclaration())
+                .filter(Objects::nonNull)
+                .map(AstHandler::getParentType)
+                .flatMap(Optional::stream)
+                .collect(Collectors.groupingBy(ClassOrInterfaceType::asString, Collectors.counting()));
 
-        final var hierarchies = new ArrayList<Hierarchy>();
-
-        for (var candidate : candidatesWithVariables) {
-            boolean belongsToHierarchy = false;
-            for (var hierarchy : hierarchies) {
-                if (hierarchy.belongs(candidate.candidate().getClassDeclaration())) {
-                    belongsToHierarchy = true;
-                    hierarchy.declarations.add(candidate.candidate().getClassDeclaration());
-                }
-            }
-
-            if (!belongsToHierarchy) {
-                hierarchies.add(new Hierarchy());
-                hierarchies.getFirst().declarations.add(candidate.candidate().getClassDeclaration());
-            }
+        if (byParent.isEmpty()) {
+            return false;
         }
 
-        return hierarchies.stream().anyMatch(h -> h.declarations.size() < 2);
+        return byParent.values().stream().anyMatch(size -> size < 2);
     }
 
     private boolean beforeFragmentReturnEqual(List<ZafeirisEtAl2016Candidate.CandidateWithVariables> candidatesWithVariables) {
@@ -101,21 +96,6 @@ public class SiblingPreconditions {
             isUsed &= AstHandler.variableIsPresentInMethodCall(var, methodCall);
         }
         return isUsed;
-    }
-
-    private class Hierarchy {
-        final Set<ClassOrInterfaceDeclaration> declarations = new HashSet<>();
-
-        boolean belongs(ClassOrInterfaceDeclaration dclr) {
-            final Optional<ClassOrInterfaceType> dclrParent = AstHandler.getParentType(dclr);
-            if (dclrParent.isEmpty()) {
-                return false;
-            }
-            return declarations.stream()
-                    .map(AstHandler::getParentType)
-                    .flatMap(Optional::stream)
-                    .anyMatch(parent -> parent.asString().equals(dclrParent.get().asString()));
-        }
     }
 
 }

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/verifiers/ZafeirisEtAl2016Verifier.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/verifiers/ZafeirisEtAl2016Verifier.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -57,16 +56,18 @@ public class ZafeirisEtAl2016Verifier {
         javaFiles.forEach(file -> {
             final var parent = AstHandler.getParent(file.getCompilationUnit(), cus).orElse(null);
 
-            this.retrieveCandidate(file, parent).ifPresent(candidates::add);
+            candidates.addAll(this.retrieveCandidates(file, parent));
         });
 
         return candidates;
     }
 
-    private Optional<ZafeirisEtAl2016Candidate> retrieveCandidate(JavaFile file, CompilationUnit parent) {
+    private List<ZafeirisEtAl2016Candidate> retrieveCandidates(JavaFile file, CompilationUnit parent) {
+
+        final var candidates = new ArrayList<ZafeirisEtAl2016Candidate>();
 
         if (this.violatesClassPreconditions(parent)) {
-            return Optional.empty();
+            return candidates;
         }
 
         final var methods = AstHandler.getMethods(file.getCompilationUnit());
@@ -96,10 +97,10 @@ public class ZafeirisEtAl2016Verifier {
                 continue;
             }
 
-            return Optional.of(this.createCandidate(file, overriddenMethod, method, superCall));
+            candidates.add(this.createCandidate(file, overriddenMethod, method, superCall));
 
         }
-        return Optional.empty();
+        return candidates;
     }
 
     private ZafeirisEtAl2016Candidate createCandidate(JavaFile file, MethodDeclaration overriddenMethod, MethodDeclaration method, SuperExpr superCall) {

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/verifiers/ZafeirisEtAl2016Verifier.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/verifiers/ZafeirisEtAl2016Verifier.java
@@ -36,6 +36,13 @@ public class ZafeirisEtAl2016Verifier {
                     .filter(c -> c.getOverriddenMethod().equals(overriddenMethod))
                     .toList();
 
+            if (candidateWithSameOverriddenMethod.size() == 1
+                    && !extractMethodPreconditions.hasMinimumFragmentsSize(
+                    candidateWithSameOverriddenMethod.getFirst().getOverridingMethod())) {
+                candidates.removeAll(candidateWithSameOverriddenMethod);
+                continue;
+            }
+
             if (siblingPreconditions.violates(candidateWithSameOverriddenMethod)) {
                 candidates.removeAll(candidates.stream()
                         .filter(c -> c.getOverriddenMethod().equals(overriddenMethod))
@@ -93,7 +100,7 @@ public class ZafeirisEtAl2016Verifier {
                     .orElseThrow(() -> new IllegalArgumentException("Super call should exists in method"));
 
             if (!this.superInvocationPreconditions.isOverriddenMethodValid(overriddenMethod, method)
-                    || !extractMethodPreconditions.isValid(overriddenMethod, method)) {
+                    || !extractMethodPreconditions.isValidIgnoringMinSize(overriddenMethod, method)) {
                 continue;
             }
 

--- a/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/weiL/verifiers/WeiEtAl2014FactoryVerifierTest.java
+++ b/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/weiL/verifiers/WeiEtAl2014FactoryVerifierTest.java
@@ -1,6 +1,7 @@
 package br.com.magnus.detectionandrefactoring.consumer.refactor.methods.weiL.verifiers;
 
 import br.com.magnus.config.starter.file.JavaFile;
+import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AstHandler;
 import br.com.magnus.detectionandrefactoring.refactor.methods.weiL.verifiers.WeiEtAl2014FactoryVerifier;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
@@ -158,6 +159,18 @@ class WeiEtAl2014FactoryVerifierTest {
         var result = this.weiEtAl2014FactoryVerifier.retrieveCandidatesFrom(files);
 
         assertEquals(1, result.size());
+    }
+
+    @Test
+    @DisplayName("Should not retrieve candidate when method has more than one parameter")
+    public void shouldNotRetrieveCandidateWhenMethodHasMoreThanOneParameter() {
+        var files = createJavaFilesFactory();
+        var method = AstHandler.getMethods(files.getLast().getCompilationUnit()).getFirst();
+        method.addParameter("int", "extra");
+
+        var result = this.weiEtAl2014FactoryVerifier.retrieveCandidatesFrom(files);
+
+        assertTrue(result.isEmpty());
     }
 
 

--- a/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/weiL/verifiers/WeiEtAl2014FactoryVerifierTest.java
+++ b/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/weiL/verifiers/WeiEtAl2014FactoryVerifierTest.java
@@ -6,6 +6,7 @@ import br.com.magnus.detectionandrefactoring.refactor.methods.weiL.verifiers.Wei
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.stmt.IfStmt;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -167,6 +168,19 @@ class WeiEtAl2014FactoryVerifierTest {
         var files = createJavaFilesFactory();
         var method = AstHandler.getMethods(files.getLast().getCompilationUnit()).getFirst();
         method.addParameter("int", "extra");
+
+        var result = this.weiEtAl2014FactoryVerifier.retrieveCandidatesFrom(files);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should not retrieve candidate when method contains nested if statements")
+    public void shouldNotRetrieveCandidateWhenMethodContainsNestedIfStatements() {
+        var files = createJavaFilesFactory();
+        var method = AstHandler.getMethods(files.getLast().getCompilationUnit()).getFirst();
+        var topLevelIf = AstHandler.getIfStatements(method).stream().findFirst().orElseThrow();
+        topLevelIf.getThenStmt().asBlockStmt().addStatement(new IfStmt());
 
         var result = this.weiEtAl2014FactoryVerifier.retrieveCandidatesFrom(files);
 

--- a/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/weiL/verifiers/WeiEtAl2014StrategyVerifierTest.java
+++ b/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/weiL/verifiers/WeiEtAl2014StrategyVerifierTest.java
@@ -6,6 +6,7 @@ import br.com.magnus.detectionandrefactoring.refactor.methods.weiL.verifiers.Wei
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.stmt.IfStmt;
 import fixtures.Wei;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -167,6 +168,19 @@ class WeiEtAl2014StrategyVerifierTest {
         var files = Wei.createJavaFilesStrategy();
         var method = AstHandler.getMethods(files.getFirst().getCompilationUnit()).getFirst();
         method.addParameter("int", "extra");
+
+        var result = this.weiEtAl2014StrategyVerifier.retrieveCandidatesFrom(files);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should not retrieve candidate when method contains nested if statements")
+    public void shouldNotRetrieveCandidateWhenMethodContainsNestedIfStatements() {
+        var files = Wei.createJavaFilesStrategy();
+        var method = AstHandler.getMethods(files.getFirst().getCompilationUnit()).getFirst();
+        var topLevelIf = AstHandler.getIfStatements(method).stream().findFirst().orElseThrow();
+        topLevelIf.getThenStmt().asBlockStmt().addStatement(new IfStmt());
 
         var result = this.weiEtAl2014StrategyVerifier.retrieveCandidatesFrom(files);
 

--- a/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/weiL/verifiers/WeiEtAl2014StrategyVerifierTest.java
+++ b/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/weiL/verifiers/WeiEtAl2014StrategyVerifierTest.java
@@ -1,6 +1,7 @@
 package br.com.magnus.detectionandrefactoring.consumer.refactor.methods.weiL.verifiers;
 
 import br.com.magnus.config.starter.file.JavaFile;
+import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AstHandler;
 import br.com.magnus.detectionandrefactoring.refactor.methods.weiL.verifiers.WeiEtAl2014StrategyVerifier;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
@@ -158,6 +159,18 @@ class WeiEtAl2014StrategyVerifierTest {
         var result = this.weiEtAl2014StrategyVerifier.retrieveCandidatesFrom(files);
 
         assertEquals(1, result.size());
+    }
+
+    @Test
+    @DisplayName("Should not retrieve candidate when method has more than one parameter")
+    public void shouldNotRetrieveCandidateWhenMethodHasMoreThanOneParameter() {
+        var files = Wei.createJavaFilesStrategy();
+        var method = AstHandler.getMethods(files.getFirst().getCompilationUnit()).getFirst();
+        method.addParameter("int", "extra");
+
+        var result = this.weiEtAl2014StrategyVerifier.retrieveCandidatesFrom(files);
+
+        assertTrue(result.isEmpty());
     }
 
 }

--- a/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/zaiferisVE/preconditions/ExtractMethodPreconditionsTest.java
+++ b/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/zaiferisVE/preconditions/ExtractMethodPreconditionsTest.java
@@ -10,6 +10,7 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.stmt.ThrowStmt;
+import com.github.javaparser.ast.stmt.TryStmt;
 import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.ast.type.VarType;
 import com.github.javaparser.ast.type.VoidType;
@@ -242,6 +243,39 @@ class ExtractMethodPreconditionsTest {
                         new ExpressionStmt(new VariableDeclarationExpr(new PrimitiveType(), "primitive2")),
                         new ExpressionStmt(new VariableDeclarationExpr(new PrimitiveType(), "primitive3")),
                         new ExpressionStmt(new MethodCallExpr("super", new NameExpr("primitive"), superExpr))
+                )));
+
+        var result = this.extractMethodPreconditions.isValid(overriddenMethod, method);
+
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("Should return true when super invocation is nested in a try block")
+    public void shouldReturnTrueWhenSuperInvocationIsNestedInTryBlock() {
+        var overriddenMethod = new MethodDeclaration(
+                NodeList.nodeList(Modifier.publicModifier()),
+                "overridenMethod",
+                new VoidType(),
+                NodeList.nodeList()
+        );
+        var superExpr = new SuperExpr();
+        var tryStmt = new TryStmt();
+        tryStmt.setTryBlock(new BlockStmt(NodeList.nodeList(
+                new ExpressionStmt(new MethodCallExpr("super", new NameExpr("primitive"), superExpr))
+        )));
+        var method = new MethodDeclaration(
+                NodeList.nodeList(Modifier.publicModifier()),
+                NodeList.nodeList(),
+                NodeList.nodeList(),
+                new VoidType(),
+                new SimpleName("parentMethod"),
+                NodeList.nodeList(),
+                NodeList.nodeList(),
+                new BlockStmt(NodeList.nodeList(
+                        new ExpressionStmt(new VariableDeclarationExpr(new PrimitiveType(), "primitive")),
+                        new ExpressionStmt(new VariableDeclarationExpr(new PrimitiveType(), "primitive2")),
+                        tryStmt
                 )));
 
         var result = this.extractMethodPreconditions.isValid(overriddenMethod, method);

--- a/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/zaiferisVE/preconditions/SiblingPreconditionsTest.java
+++ b/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/zaiferisVE/preconditions/SiblingPreconditionsTest.java
@@ -113,7 +113,7 @@ class SiblingPreconditionsTest {
                         new ExpressionStmt(new VariableDeclarationExpr(new PrimitiveType(), "primitive2")),
                         new ExpressionStmt(new MethodCallExpr("super", new SuperExpr(),
                                 new NameExpr("varIf"),
-                                new NameExpr("var5"),
+                                new NameExpr("var"),
                                 new NameExpr("primitive"),
                                 new NameExpr("primitive2")
                         )),
@@ -172,8 +172,8 @@ class SiblingPreconditionsTest {
 
 
     @Test
-    @DisplayName("Should return false when variables have the same name")
-    public void shouldReturnFalseWhenVariablesHaveTheSameName() {
+    @DisplayName("Should return true when sibling variables are not extractable from all fragments")
+    public void shouldReturnTrueWhenSiblingVariablesAreNotExtractableFromAllFragments() {
         var superExpr = new SuperExpr();
         superExpr.setParentNode(new MethodCallExpr());
         var method = new MethodDeclaration(
@@ -245,6 +245,6 @@ class SiblingPreconditionsTest {
 
         var result = siblingPreconditions.violates(candidates);
 
-        assertFalse(result);
+        assertTrue(result);
     }
 }

--- a/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/zaiferisVE/preconditions/SiblingPreconditionsTest.java
+++ b/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/zaiferisVE/preconditions/SiblingPreconditionsTest.java
@@ -112,10 +112,7 @@ class SiblingPreconditionsTest {
                         new ExpressionStmt(new VariableDeclarationExpr(new PrimitiveType(), "primitive")),
                         new ExpressionStmt(new VariableDeclarationExpr(new PrimitiveType(), "primitive2")),
                         new ExpressionStmt(new MethodCallExpr("super", new SuperExpr(),
-                                new NameExpr("varIf"),
-                                new NameExpr("var"),
-                                new NameExpr("primitive"),
-                                new NameExpr("primitive2")
+                                new NameExpr("var5")
                         )),
                         new ReturnStmt())));
         var method2 = new MethodDeclaration(
@@ -189,10 +186,7 @@ class SiblingPreconditionsTest {
                         new ExpressionStmt(new VariableDeclarationExpr(new PrimitiveType(), "primitive")),
                         new ExpressionStmt(new VariableDeclarationExpr(new PrimitiveType(), "primitive2")),
                         new ExpressionStmt(new MethodCallExpr("super", new SuperExpr(),
-                                new NameExpr("varIf"),
-                                new NameExpr("var5"),
-                                new NameExpr("primitive"),
-                                new NameExpr("primitive2")
+                                new NameExpr("var")
                         )),
                         new ReturnStmt())));
 

--- a/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/zaiferisVE/verifiers/ZafeirisEtAl2016VerifierTest.java
+++ b/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/zaiferisVE/verifiers/ZafeirisEtAl2016VerifierTest.java
@@ -72,7 +72,7 @@ class ZafeirisEtAl2016VerifierTest {
 
         var candidate = zafeirisEtAl2016Verifier.retrieveCandidatesFrom(javaFiles);
 
-        verify(extractMethodPreconditions, never()).isValid(any(), any());
+        verify(extractMethodPreconditions, never()).isValidIgnoringMinSize(any(), any());
         verify(siblingPreconditions, never()).violates(any());
         assertEquals(0, candidate.size());
     }
@@ -83,7 +83,7 @@ class ZafeirisEtAl2016VerifierTest {
         var javaFiles = createJavaFiles();
         when(superInvocationPreconditions.violatesAmountOfSuperCallsOrName(any(), any())).thenReturn(false);
         when(superInvocationPreconditions.isOverriddenMethodValid(any(), any())).thenReturn(true);
-        when(extractMethodPreconditions.isValid(any(), any())).thenReturn(false);
+        when(extractMethodPreconditions.isValidIgnoringMinSize(any(), any())).thenReturn(false);
 
         var candidate = zafeirisEtAl2016Verifier.retrieveCandidatesFrom(javaFiles);
 
@@ -97,7 +97,8 @@ class ZafeirisEtAl2016VerifierTest {
         var javaFiles = createJavaFiles();
         when(superInvocationPreconditions.violatesAmountOfSuperCallsOrName(any(), any())).thenReturn(false);
         when(superInvocationPreconditions.isOverriddenMethodValid(any(), any())).thenReturn(true);
-        when(extractMethodPreconditions.isValid(any(), any())).thenReturn(true);
+        when(extractMethodPreconditions.isValidIgnoringMinSize(any(), any())).thenReturn(true);
+        when(extractMethodPreconditions.hasMinimumFragmentsSize(any())).thenReturn(true);
         when(siblingPreconditions.violates(any())).thenReturn(true);
 
         var candidate = zafeirisEtAl2016Verifier.retrieveCandidatesFrom(javaFiles);
@@ -112,7 +113,8 @@ class ZafeirisEtAl2016VerifierTest {
         var javaFiles = createJavaFiles();
         when(superInvocationPreconditions.violatesAmountOfSuperCallsOrName(any(), any())).thenReturn(false);
         when(superInvocationPreconditions.isOverriddenMethodValid(any(), any())).thenReturn(true);
-        when(extractMethodPreconditions.isValid(any(), any())).thenReturn(true);
+        when(extractMethodPreconditions.isValidIgnoringMinSize(any(), any())).thenReturn(true);
+        when(extractMethodPreconditions.hasMinimumFragmentsSize(any())).thenReturn(true);
         when(siblingPreconditions.violates(any())).thenReturn(false);
 
         var candidate = zafeirisEtAl2016Verifier.retrieveCandidatesFrom(javaFiles);
@@ -163,7 +165,8 @@ class ZafeirisEtAl2016VerifierTest {
 
         when(superInvocationPreconditions.violatesAmountOfSuperCallsOrName(any(), any())).thenReturn(false);
         when(superInvocationPreconditions.isOverriddenMethodValid(any(), any())).thenReturn(true);
-        when(extractMethodPreconditions.isValid(any(), any())).thenReturn(true);
+        when(extractMethodPreconditions.isValidIgnoringMinSize(any(), any())).thenReturn(true);
+        when(extractMethodPreconditions.hasMinimumFragmentsSize(any())).thenReturn(true);
         when(siblingPreconditions.violates(any())).thenReturn(false);
 
         var candidate = zafeirisEtAl2016Verifier.retrieveCandidatesFrom(javaFiles);

--- a/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/zaiferisVE/verifiers/ZafeirisEtAl2016VerifierTest.java
+++ b/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/zaiferisVE/verifiers/ZafeirisEtAl2016VerifierTest.java
@@ -1,5 +1,7 @@
 package br.com.magnus.detectionandrefactoring.consumer.refactor.methods.zaiferisVE.verifiers;
 
+import br.com.magnus.config.starter.file.JavaFile;
+import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AbstractSyntaxTree;
 import br.com.magnus.detectionandrefactoring.refactor.methods.zaiferisVE.preconditions.ExtractMethodPreconditions;
 import br.com.magnus.detectionandrefactoring.refactor.methods.zaiferisVE.preconditions.SiblingPreconditions;
 import br.com.magnus.detectionandrefactoring.refactor.methods.zaiferisVE.preconditions.SuperInvocationPreconditions;
@@ -116,6 +118,57 @@ class ZafeirisEtAl2016VerifierTest {
         var candidate = zafeirisEtAl2016Verifier.retrieveCandidatesFrom(javaFiles);
 
         assertEquals(1, candidate.size());
+    }
+
+    @Test
+    @DisplayName("Should retrieve all valid super-invocation candidates from the same class")
+    public void shouldRetrieveAllValidSuperInvocationCandidatesFromSameClass() {
+        var parentSource = """
+                package sample;
+                public class Parent {
+                    protected int a() { return 1; }
+                    protected int b() { return 2; }
+                }
+                """;
+        var childSource = """
+                package sample;
+                public class Child extends Parent {
+                    @Override
+                    protected int a() {
+                        int x = 1;
+                        return super.a() + x;
+                    }
+                    @Override
+                    protected int b() {
+                        int y = 2;
+                        return super.b() + y;
+                    }
+                }
+                """;
+
+        var javaFiles = List.of(
+                JavaFile.builder()
+                        .name("Parent.java")
+                        .path("sample/")
+                        .originalClass(parentSource)
+                        .parsed(AbstractSyntaxTree.parseSingle(parentSource))
+                        .build(),
+                JavaFile.builder()
+                        .name("Child.java")
+                        .path("sample/")
+                        .originalClass(childSource)
+                        .parsed(AbstractSyntaxTree.parseSingle(childSource))
+                        .build()
+        );
+
+        when(superInvocationPreconditions.violatesAmountOfSuperCallsOrName(any(), any())).thenReturn(false);
+        when(superInvocationPreconditions.isOverriddenMethodValid(any(), any())).thenReturn(true);
+        when(extractMethodPreconditions.isValid(any(), any())).thenReturn(true);
+        when(siblingPreconditions.violates(any())).thenReturn(false);
+
+        var candidate = zafeirisEtAl2016Verifier.retrieveCandidatesFrom(javaFiles);
+
+        assertEquals(2, candidate.size());
     }
 
 }


### PR DESCRIPTION
## Summary
- enforce Wei 2014 verifier limitation to single-parameter candidate methods
- fix Zafeiris sibling precondition violation logic to reject on any violated sibling condition
- evaluate all valid Zafeiris super-invocation candidates in a class instead of returning only the first
- add/adjust unit tests to cover the new paper-aligned behavior

## Validation
- mvn -B test -pl detection-and-refactoring -Dtest=WeiEtAl2014StrategyVerifierTest,WeiEtAl2014FactoryVerifierTest,ZafeirisEtAl2016VerifierTest,SiblingPreconditionsTest
- mvn -B test -pl detection-and-refactoring