### PR TITLE
feat: implement Cinneide transformations and harden extraction paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,15 @@ The project is organized as a Maven monorepo with independent Spring Boot servic
 
 - **Strategy** and **Factory Method** detection based on Wei et al. (2014)
 - **Template Method** detection based on Zafeiris et al. (2016)
+- **Cinneide refactoring tool methods** for composed mini-transformations
 - Quality comparison between original and refactored code
+
+### Cinneide Tool Methods
+
+Implemented in `detection-and-refactoring` as AST transformations:
+
+- Mini-transformations: `ABSTRACTION`, `ENCAPSULATE_CONSTRUCTION`, `ABSTRACT_ACCESS`, `PARTIAL_ABSTRACTION`, `DELEGATION`, `WRAPPER`
+- Composed pattern methods: `applyFactoryMethod`, `applySingleton`, `applyAbstractFactory`, `applyStrategy`, `applyBridge`
 
 ## Modules
 
@@ -125,3 +133,4 @@ The API returns a project identifier that can be used to poll the analysis statu
 
 - Liu Wei, Hu Zhi-gang, Liu Hong-tao, and Yang Liu. (2014). *Automated pattern-directed refactoring for complex conditional statements*
 - Vassilis E. Zafeiris, Sotiris H. Poulias, N.A. Diamantidis, and E.A. Giakoumakis. (2017). *Automated refactoring of super-class method invocations to the Template Method design pattern*
+- Mel Ó Cinnéide. (2000). *Automated Application of Design Patterns: A Refactoring Approach*. PhD thesis, Trinity College Dublin, University of Dublin.

--- a/config-starter/src/main/java/br/com/magnus/config/starter/file/JavaFile.java
+++ b/config-starter/src/main/java/br/com/magnus/config/starter/file/JavaFile.java
@@ -27,6 +27,10 @@ public class JavaFile implements Cloneable {
         return null;
     }
 
+    public String getName() {
+        return this.name;
+    }
+
     public String getFileNameWithoutExtension() {
         return this.name.substring(0, this.name.lastIndexOf('.'));
     }

--- a/config-starter/src/main/java/br/com/magnus/config/starter/file/JavaFile.java
+++ b/config-starter/src/main/java/br/com/magnus/config/starter/file/JavaFile.java
@@ -27,7 +27,7 @@ public class JavaFile implements Cloneable {
         return null;
     }
 
-    public String getName() {
+    public Object getName() {
         return this.name;
     }
 

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/CinneideContext.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/CinneideContext.java
@@ -1,0 +1,62 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide;
+
+import br.com.magnus.config.starter.file.JavaFile;
+import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AbstractSyntaxTree;
+import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AstHandler;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.PackageDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+public class CinneideContext {
+
+    private final List<JavaFile> javaFiles;
+
+    public CinneideContext(List<JavaFile> javaFiles) {
+        this.javaFiles = javaFiles;
+    }
+
+    public List<JavaFile> files() {
+        return javaFiles;
+    }
+
+    public JavaFile classFile(String className) {
+        return javaFiles.stream()
+                .filter(file -> file.getFileNameWithoutExtension().equals(className))
+                .findFirst()
+                .orElseThrow(() -> new CinneideTransformationException("Class not found: " + className));
+    }
+
+    public CompilationUnit compilationUnit(String className) {
+        return classFile(className).getCompilationUnit();
+    }
+
+    public ClassOrInterfaceDeclaration classDeclaration(String className) {
+        return AstHandler.getClassOrInterfaceDeclaration(compilationUnit(className))
+                .orElseThrow(() -> new CinneideTransformationException("Class declaration not found: " + className));
+    }
+
+    public Optional<PackageDeclaration> packageDeclaration(String className) {
+        return compilationUnit(className).getPackageDeclaration();
+    }
+
+    public void addClass(String className, String path, CompilationUnit cu) {
+        var javaFile = JavaFile.builder()
+                .name(className + ".java")
+                .path(path)
+                .originalClass(cu.toString())
+                .parsed(AbstractSyntaxTree.parseSingle(cu.toString()))
+                .build();
+        var existingIndex = IntStream.range(0, javaFiles.size())
+                .filter(index -> javaFiles.get(index).getFileNameWithoutExtension().equals(className))
+                .findFirst();
+        if (existingIndex.isPresent()) {
+            javaFiles.set(existingIndex.getAsInt(), javaFile);
+            return;
+        }
+        javaFiles.add(javaFile);
+    }
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/CinneideRefactoringTool.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/CinneideRefactoringTool.java
@@ -1,0 +1,46 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide;
+
+import br.com.magnus.config.starter.file.JavaFile;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.transformations.AbstractFactoryPatternTransformation;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.transformations.BridgePatternTransformation;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.transformations.FactoryMethodPatternTransformation;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.transformations.SingletonPatternTransformation;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.transformations.StrategyPatternTransformation;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+
+@Component
+public class CinneideRefactoringTool {
+
+    public List<JavaFile> applyFactoryMethod(List<JavaFile> files, String creatorClass, String productClass, String productInterface, String abstractCreator, String createMethodName) {
+        var context = new CinneideContext(files);
+        new FactoryMethodPatternTransformation(creatorClass, productClass, productInterface, abstractCreator, createMethodName).apply(context);
+        return context.files();
+    }
+
+    public List<JavaFile> applySingleton(List<JavaFile> files, String concreteSingletonClass, String newAbstractSingletonClass) {
+        var context = new CinneideContext(files);
+        new SingletonPatternTransformation(concreteSingletonClass, newAbstractSingletonClass).apply(context);
+        return context.files();
+    }
+
+    public List<JavaFile> applyAbstractFactory(List<JavaFile> files, Set<String> productClasses, String newFactoryName, String newAbstractFactoryName) {
+        var context = new CinneideContext(files);
+        new AbstractFactoryPatternTransformation(productClasses, newFactoryName, newAbstractFactoryName).apply(context);
+        return context.files();
+    }
+
+    public List<JavaFile> applyStrategy(List<JavaFile> files, String contextClass, Set<String> strategyMethods, String strategyClass) {
+        var context = new CinneideContext(files);
+        new StrategyPatternTransformation(contextClass, strategyMethods, strategyClass).apply(context);
+        return context.files();
+    }
+
+    public List<JavaFile> applyBridge(List<JavaFile> files, Set<String> clientClasses, String interfaceName, String bridgeClassName) {
+        var context = new CinneideContext(files);
+        new BridgePatternTransformation(clientClasses, interfaceName, bridgeClassName).apply(context);
+        return context.files();
+    }
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/CinneideTransformationException.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/CinneideTransformationException.java
@@ -1,0 +1,7 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide;
+
+public class CinneideTransformationException extends RuntimeException {
+    public CinneideTransformationException(String message) {
+        super(message);
+    }
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/minipatterns/AbstractAccessMiniTransformation.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/minipatterns/AbstractAccessMiniTransformation.java
@@ -1,0 +1,60 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns;
+
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideContext;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+
+import java.util.Set;
+
+public class AbstractAccessMiniTransformation implements MiniTransformation {
+
+    private final String contextClassName;
+    private final String concreteClassName;
+    private final String interfaceName;
+    private final Set<String> skipMethodNames;
+
+    public AbstractAccessMiniTransformation(String contextClassName, String concreteClassName, String interfaceName, Set<String> skipMethodNames) {
+        this.contextClassName = contextClassName;
+        this.concreteClassName = concreteClassName;
+        this.interfaceName = interfaceName;
+        this.skipMethodNames = skipMethodNames;
+    }
+
+    @Override
+    public void apply(CinneideContext context) {
+        var contextClass = context.classDeclaration(contextClassName);
+        contextClass.findAll(FieldDeclaration.class).forEach(this::replaceTypeIfConcrete);
+        contextClass.findAll(VariableDeclarator.class).forEach(this::replaceTypeIfConcrete);
+
+        contextClass.findAll(MethodDeclaration.class).stream()
+                .filter(method -> !skipMethodNames.contains(method.getNameAsString()))
+                .forEach(method -> {
+                    if (method.getType().isClassOrInterfaceType()
+                            && method.getType().asClassOrInterfaceType().getNameAsString().equals(concreteClassName)) {
+                        method.setType(new ClassOrInterfaceType(interfaceName));
+                    }
+                    method.findAll(Parameter.class).forEach(this::replaceTypeIfConcrete);
+                });
+    }
+
+    private void replaceTypeIfConcrete(FieldDeclaration fieldDeclaration) {
+        fieldDeclaration.getVariables().forEach(this::replaceTypeIfConcrete);
+    }
+
+    private void replaceTypeIfConcrete(Parameter parameter) {
+        if (parameter.getType().isClassOrInterfaceType()
+                && parameter.getType().asClassOrInterfaceType().getNameAsString().equals(concreteClassName)) {
+            parameter.setType(new ClassOrInterfaceType(interfaceName));
+        }
+    }
+
+    private void replaceTypeIfConcrete(VariableDeclarator variableDeclarator) {
+        if (variableDeclarator.getType().isClassOrInterfaceType()
+                && variableDeclarator.getType().asClassOrInterfaceType().getNameAsString().equals(concreteClassName)) {
+            variableDeclarator.setType(new ClassOrInterfaceType(interfaceName));
+        }
+    }
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/minipatterns/AbstractionMiniTransformation.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/minipatterns/AbstractionMiniTransformation.java
@@ -1,0 +1,63 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns;
+
+import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AstHandler;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideContext;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideTransformationException;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.MethodDeclaration;
+
+public class AbstractionMiniTransformation implements MiniTransformation {
+
+    private final String concreteClassName;
+    private final String interfaceName;
+
+    public AbstractionMiniTransformation(String concreteClassName, String interfaceName) {
+        this.concreteClassName = concreteClassName;
+        this.interfaceName = interfaceName;
+    }
+
+    @Override
+    public void apply(CinneideContext context) {
+        var concreteClass = context.classDeclaration(concreteClassName);
+        var concreteCu = context.compilationUnit(concreteClassName);
+
+        if (concreteClass.getImplementedTypes().stream().noneMatch(i -> i.getNameAsString().equals(interfaceName))) {
+            concreteClass.addImplementedType(interfaceName);
+        }
+
+        CompilationUnit interfaceCu;
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration interfaceDcl;
+        try {
+            interfaceCu = context.compilationUnit(interfaceName);
+            interfaceDcl = context.classDeclaration(interfaceName);
+        } catch (CinneideTransformationException ignored) {
+            interfaceCu = new CompilationUnit();
+            var packageDeclaration = concreteCu.getPackageDeclaration();
+            if (packageDeclaration.isPresent()) {
+                interfaceCu.setPackageDeclaration(packageDeclaration.get().getNameAsString());
+            }
+            interfaceDcl = interfaceCu.addInterface(interfaceName);
+        }
+        var finalInterfaceCu = interfaceCu;
+        var finalInterfaceDcl = interfaceDcl;
+
+        AstHandler.getMethods(concreteClass).stream()
+                .filter(MethodDeclaration::isPublic)
+                .filter(method -> finalInterfaceDcl.getMethodsByName(method.getNameAsString()).stream()
+                        .noneMatch(existing -> existing.getSignature().equals(method.getSignature())))
+                .forEach(method -> finalInterfaceDcl.addMember(toAbstractSignature(method)));
+
+        var path = context.classFile(concreteClassName).getPath();
+        context.addClass(interfaceName, path, finalInterfaceCu);
+    }
+
+    private MethodDeclaration toAbstractSignature(MethodDeclaration method) {
+        var signature = new MethodDeclaration();
+        signature.setName(method.getNameAsString());
+        signature.setType(method.getType());
+        signature.setModifiers(Modifier.Keyword.PUBLIC);
+        method.getParameters().forEach(signature::addParameter);
+        return signature;
+    }
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/minipatterns/DelegationMiniTransformation.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/minipatterns/DelegationMiniTransformation.java
@@ -1,0 +1,70 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns;
+
+import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AstHandler;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideContext;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+
+import java.util.List;
+import java.util.Set;
+
+public class DelegationMiniTransformation implements MiniTransformation {
+
+    private final String contextClassName;
+    private final Set<String> moveMethodNames;
+    private final String delegationClassName;
+
+    public DelegationMiniTransformation(String contextClassName, Set<String> moveMethodNames, String delegationClassName) {
+        this.contextClassName = contextClassName;
+        this.moveMethodNames = moveMethodNames;
+        this.delegationClassName = delegationClassName;
+    }
+
+    @Override
+    public void apply(CinneideContext context) {
+        var contextClass = context.classDeclaration(contextClassName);
+        var contextCu = context.compilationUnit(contextClassName);
+        var delegationCu = new CompilationUnit();
+        contextCu.getPackageDeclaration().ifPresent(pkg -> delegationCu.setPackageDeclaration(pkg.getNameAsString()));
+        var delegationClass = delegationCu.addClass(delegationClassName);
+
+        if (contextClass.getFieldByName("delegation").isEmpty()) {
+            var field = new VariableDeclarator(new ClassOrInterfaceType(delegationClassName), "delegation", new ObjectCreationExpr().setType(delegationClassName));
+            contextClass.addMember(new com.github.javaparser.ast.body.FieldDeclaration().addVariable(field).setModifiers(Modifier.Keyword.PRIVATE, Modifier.Keyword.FINAL));
+        }
+
+        var contextMethods = List.copyOf(AstHandler.getMethods(contextClass));
+        for (var method : contextMethods) {
+            if (!moveMethodNames.contains(method.getNameAsString())) {
+                continue;
+            }
+            var moved = method.clone();
+            moved.setModifiers(Modifier.Keyword.PUBLIC);
+            delegationClass.addMember(moved);
+            method.setBody(delegateBody(method));
+        }
+
+        var path = context.classFile(contextClassName).getPath();
+        context.addClass(delegationClassName, path, delegationCu);
+    }
+
+    private BlockStmt delegateBody(MethodDeclaration method) {
+        var call = new MethodCallExpr(new NameExpr("delegation"), method.getNameAsString());
+        method.getParameters().stream()
+                .map(Parameter::getNameAsString)
+                .map(NameExpr::new)
+                .forEach(call::addArgument);
+        if (method.getType().isVoidType()) {
+            return new BlockStmt().addStatement(new ExpressionStmt(call));
+        }
+        return new BlockStmt().addStatement(new ReturnStmt(call));
+    }
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/minipatterns/EncapsulateConstructionMiniTransformation.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/minipatterns/EncapsulateConstructionMiniTransformation.java
@@ -1,0 +1,91 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns;
+
+import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AstHandler;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideContext;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.PrimitiveType;
+import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.ast.type.UnknownType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EncapsulateConstructionMiniTransformation implements MiniTransformation {
+
+    private final String creatorClassName;
+    private final String productClassName;
+    private final String createMethodName;
+
+    public EncapsulateConstructionMiniTransformation(String creatorClassName, String productClassName, String createMethodName) {
+        this.creatorClassName = creatorClassName;
+        this.productClassName = productClassName;
+        this.createMethodName = createMethodName;
+    }
+
+    @Override
+    public void apply(CinneideContext context) {
+        var creatorClass = context.classDeclaration(creatorClassName);
+        var creations = new ArrayList<ObjectCreationExpr>();
+        AstHandler.getMethods(creatorClass).forEach(method -> method.findAll(ObjectCreationExpr.class).stream()
+                .filter(o -> o.getType().getNameAsString().equals(productClassName))
+                .forEach(creations::add));
+
+        for (var creation : creations) {
+            ensureCreatorMethod(creatorClass, creation);
+            var replacement = new MethodCallExpr(createMethodName);
+            creation.getArguments().forEach(argument -> replacement.addArgument(argument.clone()));
+            creation.replace(replacement);
+        }
+    }
+
+    private void ensureCreatorMethod(com.github.javaparser.ast.body.ClassOrInterfaceDeclaration creatorClass, ObjectCreationExpr creation) {
+        var argTypes = creation.getArguments().stream().map(this::inferType).toList();
+        var exists = AstHandler.getMethods(creatorClass).stream()
+                .filter(method -> method.getNameAsString().equals(createMethodName))
+                .anyMatch(method -> sameParamTypes(method.getParameters(), argTypes));
+
+        if (exists) {
+            return;
+        }
+
+        var method = creatorClass.addMethod(createMethodName, Modifier.Keyword.PUBLIC);
+        method.setType(new ClassOrInterfaceType(productClassName));
+        for (var i = 0; i < argTypes.size(); i++) {
+            method.addParameter(new Parameter(argTypes.get(i), "arg" + i));
+        }
+        var objectCreation = new ObjectCreationExpr();
+        objectCreation.setType(productClassName);
+        method.getParameters().forEach(parameter -> objectCreation.addArgument(new NameExpr(parameter.getNameAsString())));
+        method.setBody(new BlockStmt().addStatement(new ReturnStmt(objectCreation)));
+    }
+
+    private boolean sameParamTypes(List<Parameter> parameters, List<Type> argTypes) {
+        if (parameters.size() != argTypes.size()) {
+            return false;
+        }
+        for (int i = 0; i < parameters.size(); i++) {
+            if (!parameters.get(i).getType().equals(argTypes.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private Type inferType(Expression expression) {
+        if (expression.isIntegerLiteralExpr()) return PrimitiveType.intType();
+        if (expression.isLongLiteralExpr()) return PrimitiveType.longType();
+        if (expression.isBooleanLiteralExpr()) return PrimitiveType.booleanType();
+        if (expression.isDoubleLiteralExpr()) return PrimitiveType.doubleType();
+        if (expression.isCharLiteralExpr()) return PrimitiveType.charType();
+        if (expression.isStringLiteralExpr()) return new ClassOrInterfaceType("String");
+        if (expression.isNameExpr()) return new ClassOrInterfaceType("Object");
+        if (expression.isMethodCallExpr()) return new ClassOrInterfaceType("Object");
+        return new UnknownType();
+    }
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/minipatterns/MiniTransformation.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/minipatterns/MiniTransformation.java
@@ -1,0 +1,7 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns;
+
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideContext;
+
+public interface MiniTransformation {
+    void apply(CinneideContext context);
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/minipatterns/PartialAbstractionMiniTransformation.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/minipatterns/PartialAbstractionMiniTransformation.java
@@ -1,0 +1,62 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns;
+
+import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AstHandler;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideContext;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+
+import java.util.List;
+import java.util.Set;
+
+public class PartialAbstractionMiniTransformation implements MiniTransformation {
+
+    private final String concreteClassName;
+    private final String abstractClassName;
+    private final Set<String> abstractMethodNames;
+
+    public PartialAbstractionMiniTransformation(String concreteClassName, String abstractClassName, Set<String> abstractMethodNames) {
+        this.concreteClassName = concreteClassName;
+        this.abstractClassName = abstractClassName;
+        this.abstractMethodNames = abstractMethodNames;
+    }
+
+    @Override
+    public void apply(CinneideContext context) {
+        var concreteClass = context.classDeclaration(concreteClassName);
+        var concreteCu = context.compilationUnit(concreteClassName);
+        var abstractCu = new CompilationUnit();
+        concreteCu.getPackageDeclaration().ifPresent(pkg -> abstractCu.setPackageDeclaration(pkg.getNameAsString()));
+        var abstractClass = abstractCu.addClass(abstractClassName);
+        abstractClass.setAbstract(true);
+
+        var methods = List.copyOf(AstHandler.getMethods(concreteClass));
+        for (var method : methods) {
+            if (abstractMethodNames.contains(method.getNameAsString())) {
+                abstractClass.addMember(toAbstractSignature(method));
+                continue;
+            }
+            abstractClass.addMember(method.clone());
+            concreteClass.remove(method);
+        }
+
+        concreteClass.getExtendedTypes().clear();
+        concreteClass.addExtendedType(abstractClassName);
+        var path = context.classFile(concreteClassName).getPath();
+        context.addClass(abstractClassName, path, abstractCu);
+    }
+
+    private MethodDeclaration toAbstractSignature(MethodDeclaration method) {
+        var signature = new MethodDeclaration();
+        signature.setName(method.getNameAsString());
+        signature.setType(method.getType());
+        if (method.isProtected()) {
+            signature.setModifiers(Modifier.Keyword.PROTECTED, Modifier.Keyword.ABSTRACT);
+        } else {
+            signature.setModifiers(Modifier.Keyword.PUBLIC, Modifier.Keyword.ABSTRACT);
+        }
+        method.getParameters().forEach(parameter -> signature.addParameter(new Parameter(parameter.getType(), parameter.getName())));
+        return signature;
+    }
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/minipatterns/WrapperMiniTransformation.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/minipatterns/WrapperMiniTransformation.java
@@ -1,0 +1,100 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns;
+
+import br.com.magnus.config.starter.file.JavaFile;
+import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AstHandler;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideContext;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+
+import java.util.List;
+import java.util.Set;
+
+public class WrapperMiniTransformation implements MiniTransformation {
+
+    private final Set<String> clientClassNames;
+    private final String interfaceName;
+    private final String wrapperClassName;
+
+    public WrapperMiniTransformation(Set<String> clientClassNames, String interfaceName, String wrapperClassName) {
+        this.clientClassNames = clientClassNames;
+        this.interfaceName = interfaceName;
+        this.wrapperClassName = wrapperClassName;
+    }
+
+    @Override
+    public void apply(CinneideContext context) {
+        var interfaceFile = context.classFile(interfaceName);
+        var interfaceDcl = AstHandler.getClassOrInterfaceDeclaration(interfaceFile.getCompilationUnit())
+                .orElseThrow(() -> new IllegalArgumentException("Interface not found: " + interfaceName));
+
+        var wrapperCu = new CompilationUnit();
+        interfaceFile.getCompilationUnit().getPackageDeclaration().ifPresent(pkg -> wrapperCu.setPackageDeclaration(pkg.getNameAsString()));
+        var wrapperClass = wrapperCu.addClass(wrapperClassName);
+        wrapperClass.addImplementedType(interfaceName);
+        wrapperClass.addFieldWithInitializer(interfaceName, "receiver", new NameExpr("receiver"), Modifier.Keyword.PRIVATE, Modifier.Keyword.FINAL);
+        var constructor = wrapperClass.addConstructor(Modifier.Keyword.PUBLIC);
+        constructor.addParameter(interfaceName, "receiver");
+        constructor.setBody(new BlockStmt().addStatement(new AssignExpr(new FieldAccessExpr(new ThisExpr(), "receiver"), new NameExpr("receiver"), AssignExpr.Operator.ASSIGN)));
+        var getter = wrapperClass.addMethod("getReceiver", Modifier.Keyword.PUBLIC);
+        getter.setType(interfaceName);
+        getter.setBody(new BlockStmt().addStatement(new ReturnStmt(new NameExpr("receiver"))));
+
+        AstHandler.getMethods(interfaceDcl).forEach(interfaceMethod -> wrapperClass.addMember(delegateMethod(interfaceMethod)));
+        context.addClass(wrapperClassName, interfaceFile.getPath(), wrapperCu);
+
+        var implClassNames = context.files().stream()
+                .map(JavaFile::getCompilationUnit)
+                .map(AstHandler::getClassOrInterfaceDeclaration)
+                .flatMap(java.util.Optional::stream)
+                .filter(dcl -> dcl.getImplementedTypes().stream().anyMatch(t -> t.getNameAsString().equals(interfaceName)))
+                .map(dcl -> dcl.getNameAsString())
+                .toList();
+
+        for (var clientClassName : clientClassNames) {
+            var clientClass = context.classDeclaration(clientClassName);
+            clientClass.findAll(ObjectCreationExpr.class).stream()
+                    .filter(creation -> implClassNames.contains(creation.getType().getNameAsString()))
+                    .forEach(creation -> {
+                        var wrapped = new ObjectCreationExpr();
+                        wrapped.setType(wrapperClassName);
+                        wrapped.addArgument(creation.clone());
+                        creation.replace(wrapped);
+                    });
+            clientClass.findAll(VariableDeclarator.class).forEach(var -> {
+                if (var.getType().isClassOrInterfaceType()
+                        && implClassNames.contains(var.getType().asClassOrInterfaceType().getNameAsString())) {
+                    var.setType(new ClassOrInterfaceType(wrapperClassName));
+                }
+            });
+        }
+    }
+
+    private MethodDeclaration delegateMethod(MethodDeclaration interfaceMethod) {
+        var method = new MethodDeclaration();
+        method.setName(interfaceMethod.getNameAsString());
+        method.setType(interfaceMethod.getType());
+        method.setModifiers(Modifier.Keyword.PUBLIC);
+        interfaceMethod.getParameters().forEach(parameter -> method.addParameter(new Parameter(parameter.getType(), parameter.getName())));
+
+        var delegateCall = new MethodCallExpr(new NameExpr("receiver"), method.getNameAsString());
+        method.getParameters().stream()
+                .map(Parameter::getNameAsString)
+                .map(NameExpr::new)
+                .forEach(delegateCall::addArgument);
+
+        if (method.getType().isVoidType()) {
+            method.setBody(new BlockStmt().addStatement(delegateCall));
+        } else {
+            method.setBody(new BlockStmt().addStatement(new ReturnStmt(delegateCall)));
+        }
+
+        return method;
+    }
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/transformations/AbstractFactoryPatternTransformation.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/transformations/AbstractFactoryPatternTransformation.java
@@ -1,0 +1,56 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.transformations;
+
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideContext;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns.AbstractAccessMiniTransformation;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns.AbstractionMiniTransformation;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns.EncapsulateConstructionMiniTransformation;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+
+import java.util.Set;
+
+public class AbstractFactoryPatternTransformation implements PatternTransformation {
+
+    private final Set<String> productClasses;
+    private final String newFactoryName;
+    private final String newAbstractFactoryName;
+
+    public AbstractFactoryPatternTransformation(Set<String> productClasses, String newFactoryName, String newAbstractFactoryName) {
+        this.productClasses = productClasses;
+        this.newFactoryName = newFactoryName;
+        this.newAbstractFactoryName = newAbstractFactoryName;
+    }
+
+    @Override
+    public void apply(CinneideContext context) {
+        var firstProduct = productClasses.stream().findFirst().orElseThrow();
+        var firstProductFile = context.classFile(firstProduct);
+        var factoryCu = new CompilationUnit();
+        firstProductFile.getCompilationUnit().getPackageDeclaration().ifPresent(pkg -> factoryCu.setPackageDeclaration(pkg.getNameAsString()));
+        factoryCu.addClass(newFactoryName);
+        context.addClass(newFactoryName, firstProductFile.getPath(), factoryCu);
+
+        for (var product : productClasses) {
+            var productInterface = product + "Interface";
+            new AbstractionMiniTransformation(product, productInterface).apply(context);
+            context.files().forEach(file -> {
+                if (!file.getFileNameWithoutExtension().equals(newFactoryName)) {
+                    new AbstractAccessMiniTransformation(file.getFileNameWithoutExtension(), product, productInterface, Set.of()).apply(context);
+                }
+            });
+            new EncapsulateConstructionMiniTransformation(newFactoryName, product, "create" + product).apply(context);
+        }
+
+        new SingletonPatternTransformation(newFactoryName, newAbstractFactoryName).apply(context);
+
+        context.files().forEach(file -> file.getCompilationUnit().findAll(ObjectCreationExpr.class).stream()
+                .filter(expr -> productClasses.contains(expr.getType().getNameAsString()))
+                .forEach(expr -> {
+                    var product = expr.getType().getNameAsString();
+                    var getInstance = new MethodCallExpr(new com.github.javaparser.ast.expr.NameExpr(newAbstractFactoryName), "getInstance");
+                    var create = new MethodCallExpr(getInstance, "create" + product);
+                    expr.replace(create);
+                }));
+    }
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/transformations/BridgePatternTransformation.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/transformations/BridgePatternTransformation.java
@@ -1,0 +1,24 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.transformations;
+
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideContext;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns.WrapperMiniTransformation;
+
+import java.util.Set;
+
+public class BridgePatternTransformation implements PatternTransformation {
+
+    private final Set<String> clientClasses;
+    private final String interfaceName;
+    private final String bridgeClassName;
+
+    public BridgePatternTransformation(Set<String> clientClasses, String interfaceName, String bridgeClassName) {
+        this.clientClasses = clientClasses;
+        this.interfaceName = interfaceName;
+        this.bridgeClassName = bridgeClassName;
+    }
+
+    @Override
+    public void apply(CinneideContext context) {
+        new WrapperMiniTransformation(clientClasses, interfaceName, bridgeClassName).apply(context);
+    }
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/transformations/FactoryMethodPatternTransformation.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/transformations/FactoryMethodPatternTransformation.java
@@ -1,0 +1,31 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.transformations;
+
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideContext;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns.*;
+
+import java.util.Set;
+
+public class FactoryMethodPatternTransformation implements PatternTransformation {
+
+    private final String creatorClass;
+    private final String productClass;
+    private final String productInterface;
+    private final String abstractCreator;
+    private final String createProductMethod;
+
+    public FactoryMethodPatternTransformation(String creatorClass, String productClass, String productInterface, String abstractCreator, String createProductMethod) {
+        this.creatorClass = creatorClass;
+        this.productClass = productClass;
+        this.productInterface = productInterface;
+        this.abstractCreator = abstractCreator;
+        this.createProductMethod = createProductMethod;
+    }
+
+    @Override
+    public void apply(CinneideContext context) {
+        new AbstractionMiniTransformation(productClass, productInterface).apply(context);
+        new EncapsulateConstructionMiniTransformation(creatorClass, productClass, createProductMethod).apply(context);
+        new AbstractAccessMiniTransformation(creatorClass, productClass, productInterface, Set.of(createProductMethod)).apply(context);
+        new PartialAbstractionMiniTransformation(creatorClass, abstractCreator, Set.of(createProductMethod)).apply(context);
+    }
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/transformations/PatternTransformation.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/transformations/PatternTransformation.java
@@ -1,0 +1,7 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.transformations;
+
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideContext;
+
+public interface PatternTransformation {
+    void apply(CinneideContext context);
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/transformations/SingletonPatternTransformation.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/transformations/SingletonPatternTransformation.java
@@ -1,0 +1,62 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.transformations;
+
+import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AstHandler;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideContext;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns.PartialAbstractionMiniTransformation;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SingletonPatternTransformation implements PatternTransformation {
+
+    private final String concreteSingletonClass;
+    private final String newAbstractSingletonClass;
+
+    public SingletonPatternTransformation(String concreteSingletonClass, String newAbstractSingletonClass) {
+        this.concreteSingletonClass = concreteSingletonClass;
+        this.newAbstractSingletonClass = newAbstractSingletonClass;
+    }
+
+    @Override
+    public void apply(CinneideContext context) {
+        var concrete = context.classDeclaration(concreteSingletonClass);
+        var allMethodNames = AstHandler.getMethods(concrete).stream()
+                .map(MethodDeclaration::getNameAsString)
+                .collect(Collectors.toSet());
+        new PartialAbstractionMiniTransformation(concreteSingletonClass, newAbstractSingletonClass, allMethodNames).apply(context);
+
+        var abstractSingleton = context.classDeclaration(newAbstractSingletonClass);
+        if (abstractSingleton.getFieldByName("instance").isEmpty()) {
+            abstractSingleton.addFieldWithInitializer(new ClassOrInterfaceType(newAbstractSingletonClass), "instance",
+                    new ObjectCreationExpr().setType(concreteSingletonClass), Modifier.Keyword.PRIVATE, Modifier.Keyword.STATIC);
+        }
+
+        var singletonMethod = abstractSingleton.getMethodsByName("getInstance").stream().findFirst().orElseGet(() -> {
+            var method = abstractSingleton.addMethod("getInstance", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+            method.setType(newAbstractSingletonClass);
+            return method;
+        });
+        singletonMethod.setBody(new BlockStmt().addStatement(new ReturnStmt(new NameExpr("instance"))));
+
+        context.files().forEach(file -> {
+            if (file.getFileNameWithoutExtension().equals(newAbstractSingletonClass)) {
+                return;
+            }
+            file.getCompilationUnit().findAll(ObjectCreationExpr.class).stream()
+                    .filter(expr -> expr.getType().getNameAsString().equals(concreteSingletonClass))
+                    .forEach(expr -> expr.replace(new MethodCallExpr(new NameExpr(newAbstractSingletonClass), "getInstance")));
+        });
+
+        abstractSingleton.getConstructors().forEach(constructor -> {
+            constructor.setModifiers(Modifier.Keyword.PROTECTED);
+        });
+    }
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/transformations/StrategyPatternTransformation.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/cinneide/transformations/StrategyPatternTransformation.java
@@ -1,0 +1,29 @@
+package br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.transformations;
+
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideContext;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns.AbstractAccessMiniTransformation;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns.AbstractionMiniTransformation;
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.minipatterns.DelegationMiniTransformation;
+
+import java.util.Set;
+
+public class StrategyPatternTransformation implements PatternTransformation {
+
+    private final String contextClass;
+    private final Set<String> strategyMethods;
+    private final String strategyClass;
+
+    public StrategyPatternTransformation(String contextClass, Set<String> strategyMethods, String strategyClass) {
+        this.contextClass = contextClass;
+        this.strategyMethods = strategyMethods;
+        this.strategyClass = strategyClass;
+    }
+
+    @Override
+    public void apply(CinneideContext context) {
+        var strategyInterface = strategyClass + "Interface";
+        new DelegationMiniTransformation(contextClass, strategyMethods, strategyClass).apply(context);
+        new AbstractionMiniTransformation(strategyClass, strategyInterface).apply(context);
+        new AbstractAccessMiniTransformation(contextClass, strategyClass, strategyInterface, Set.of()).apply(context);
+    }
+}

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/weiL/WeiEtAl2014Candidate.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/weiL/WeiEtAl2014Candidate.java
@@ -83,7 +83,7 @@ public abstract class WeiEtAl2014Candidate implements RefactoringCandidate {
 
     @Override
     public String getClassName() {
-        return this.file.getName();
+        return this.file.getName().toString();
     }
 
     @Override

--- a/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/ZafeirisEtAl2016Candidate.java
+++ b/detection-and-refactoring/src/main/java/br/com/magnus/detectionandrefactoring/refactor/methods/zaiferisVE/ZafeirisEtAl2016Candidate.java
@@ -66,7 +66,7 @@ public class ZafeirisEtAl2016Candidate implements RefactoringCandidate {
 
     @Override
     public String getClassName() {
-        return this.file.getName();
+        return this.file.getName().toString();
     }
 
     @Override

--- a/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/cinneide/CinneideRefactoringToolTest.java
+++ b/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/consumer/refactor/methods/cinneide/CinneideRefactoringToolTest.java
@@ -1,0 +1,88 @@
+package br.com.magnus.detectionandrefactoring.consumer.refactor.methods.cinneide;
+
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideRefactoringTool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static fixtures.Cinneide.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CinneideRefactoringToolTest {
+
+    private CinneideRefactoringTool tool;
+
+    @BeforeEach
+    void setup() {
+        tool = new CinneideRefactoringTool();
+    }
+
+    @Test
+    @DisplayName("Should apply factory method transformation")
+    void shouldApplyFactoryMethodTransformation() {
+        var files = createFactoryMethodSample();
+        var result = tool.applyFactoryMethod(files, "Creator", "Product", "ProductInterface", "AbstractCreator", "createProduct");
+
+        assertTrue(result.stream().anyMatch(file -> file.getFileNameWithoutExtension().equals("ProductInterface")));
+        assertTrue(result.stream().anyMatch(file -> file.getFileNameWithoutExtension().equals("AbstractCreator")));
+        var creator = result.stream().filter(file -> file.getFileNameWithoutExtension().equals("Creator")).findFirst().orElseThrow();
+        assertTrue(creator.getCompilationUnit().toString().contains("extends AbstractCreator"));
+        assertTrue(creator.getCompilationUnit().toString().contains("createProduct"));
+    }
+
+    @Test
+    @DisplayName("Should apply singleton transformation")
+    void shouldApplySingletonTransformation() {
+        var files = createSingletonSample();
+        var result = tool.applySingleton(files, "Service", "AbstractService");
+
+        assertTrue(result.stream().anyMatch(file -> file.getFileNameWithoutExtension().equals("AbstractService")));
+        var abstractService = result.stream().filter(file -> file.getFileNameWithoutExtension().equals("AbstractService")).findFirst().orElseThrow();
+        assertTrue(abstractService.getCompilationUnit().toString().contains("static AbstractService getInstance()"));
+        var client = result.stream().filter(file -> file.getFileNameWithoutExtension().equals("Client")).findFirst().orElseThrow();
+        assertTrue(client.getCompilationUnit().toString().contains("AbstractService.getInstance()"));
+    }
+
+    @Test
+    @DisplayName("Should apply abstract factory transformation")
+    void shouldApplyAbstractFactoryTransformation() {
+        var files = createAbstractFactorySample();
+        var result = tool.applyAbstractFactory(files, Set.of("ProductA", "ProductB"), "ConcreteFactory", "AbstractFactory");
+
+        assertTrue(result.stream().anyMatch(file -> file.getFileNameWithoutExtension().equals("ConcreteFactory")));
+        assertTrue(result.stream().anyMatch(file -> file.getFileNameWithoutExtension().equals("AbstractFactory")));
+        var client = result.stream().filter(file -> file.getFileNameWithoutExtension().equals("ClientAF")).findFirst().orElseThrow();
+        assertTrue(client.getCompilationUnit().toString().contains("AbstractFactory.getInstance().createProductA()"));
+        assertTrue(client.getCompilationUnit().toString().contains("AbstractFactory.getInstance().createProductB()"));
+    }
+
+    @Test
+    @DisplayName("Should apply strategy transformation")
+    void shouldApplyStrategyTransformation() {
+        var files = createStrategySample();
+        var result = tool.applyStrategy(files, "PricingContext", Set.of("percentage", "discount"), "PricingStrategy");
+
+        assertTrue(result.stream().anyMatch(file -> file.getFileNameWithoutExtension().equals("PricingStrategy")));
+        assertTrue(result.stream().anyMatch(file -> file.getFileNameWithoutExtension().equals("PricingStrategyInterface")));
+        var contextClass = result.stream().filter(file -> file.getFileNameWithoutExtension().equals("PricingContext")).findFirst().orElseThrow();
+        assertTrue(contextClass.getCompilationUnit().toString().contains("private final PricingStrategyInterface delegation"));
+        assertTrue(contextClass.getCompilationUnit().toString().contains("delegation.percentage"));
+    }
+
+    @Test
+    @DisplayName("Should apply bridge transformation")
+    void shouldApplyBridgeTransformation() {
+        var files = createBridgeSample();
+        var result = tool.applyBridge(files, Set.of("BridgeClient"), "Implementor", "ImplementorBridge");
+
+        assertTrue(result.stream().anyMatch(file -> file.getFileNameWithoutExtension().equals("ImplementorBridge")));
+        var bridge = result.stream().filter(file -> file.getFileNameWithoutExtension().equals("ImplementorBridge")).findFirst().orElseThrow();
+        assertTrue(bridge.getCompilationUnit().toString().contains("implements Implementor"));
+        var client = result.stream().filter(file -> file.getFileNameWithoutExtension().equals("BridgeClient")).findFirst().orElseThrow();
+        assertTrue(client.getCompilationUnit().toString().contains("new ImplementorBridge(new ConcreteImplementor())"));
+        assertEquals(4, result.size());
+    }
+}

--- a/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/integration/CinneideRefactoringToolIntegrationTest.java
+++ b/detection-and-refactoring/src/test/java/br/com/magnus/detectionandrefactoring/integration/CinneideRefactoringToolIntegrationTest.java
@@ -1,0 +1,31 @@
+package br.com.magnus.detectionandrefactoring.integration;
+
+import br.com.magnus.detectionandrefactoring.refactor.methods.cinneide.CinneideRefactoringTool;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static fixtures.Cinneide.createAbstractFactorySample;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CinneideRefactoringToolIntegrationTest {
+
+    private final CinneideRefactoringTool tool = new CinneideRefactoringTool();
+
+    @Test
+    @DisplayName("Should execute composed mini transformations through abstract factory flow")
+    void shouldExecuteComposedMiniTransformationsThroughAbstractFactoryFlow() {
+        var files = createAbstractFactorySample();
+        var result = tool.applyAbstractFactory(files, Set.of("ProductA", "ProductB"), "ConcreteFactory", "AbstractFactory");
+
+        assertTrue(result.stream().anyMatch(file -> file.getFileNameWithoutExtension().equals("ConcreteFactory")));
+        assertTrue(result.stream().anyMatch(file -> file.getFileNameWithoutExtension().equals("AbstractFactory")));
+        assertTrue(result.stream().anyMatch(file -> file.getFileNameWithoutExtension().equals("ProductAInterface")));
+        assertTrue(result.stream().anyMatch(file -> file.getFileNameWithoutExtension().equals("ProductBInterface")));
+        var abstractFactory = result.stream().filter(file -> file.getFileNameWithoutExtension().equals("AbstractFactory")).findFirst().orElseThrow();
+        var client = result.stream().filter(file -> file.getFileNameWithoutExtension().equals("ClientAF")).findFirst().orElseThrow();
+        assertTrue(abstractFactory.getCompilationUnit().toString().contains("getInstance"));
+        assertTrue(client.getCompilationUnit().toString().contains("AbstractFactory.getInstance()"));
+    }
+}

--- a/detection-and-refactoring/src/test/java/fixtures/Cinneide.java
+++ b/detection-and-refactoring/src/test/java/fixtures/Cinneide.java
@@ -1,0 +1,114 @@
+package fixtures;
+
+import br.com.magnus.config.starter.file.JavaFile;
+import br.com.magnus.detectionandrefactoring.refactor.dataExtractions.ast.AbstractSyntaxTree;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Cinneide {
+
+    public static List<JavaFile> createFactoryMethodSample() {
+        var product = """
+                package cinneide;
+                public class Product {
+                    public String value() { return "ok"; }
+                }
+                """;
+        var creator = """
+                package cinneide;
+                public class Creator {
+                    public Product build() { return new Product(); }
+                }
+                """;
+        return new ArrayList<>(List.of(
+                JavaFile.builder().name("Product.java").path("cinneide/").originalClass(product).parsed(AbstractSyntaxTree.parseSingle(product)).build(),
+                JavaFile.builder().name("Creator.java").path("cinneide/").originalClass(creator).parsed(AbstractSyntaxTree.parseSingle(creator)).build()
+        ));
+    }
+
+    public static List<JavaFile> createSingletonSample() {
+        var service = """
+                package cinneide;
+                public class Service {
+                    public String run() { return "ok"; }
+                }
+                """;
+        var client = """
+                package cinneide;
+                public class Client {
+                    public Service create() { return new Service(); }
+                }
+                """;
+        return new ArrayList<>(List.of(
+                JavaFile.builder().name("Service.java").path("cinneide/").originalClass(service).parsed(AbstractSyntaxTree.parseSingle(service)).build(),
+                JavaFile.builder().name("Client.java").path("cinneide/").originalClass(client).parsed(AbstractSyntaxTree.parseSingle(client)).build()
+        ));
+    }
+
+    public static List<JavaFile> createAbstractFactorySample() {
+        var productA = """
+                package cinneide;
+                public class ProductA {
+                    public String id() { return "A"; }
+                }
+                """;
+        var productB = """
+                package cinneide;
+                public class ProductB {
+                    public String id() { return "B"; }
+                }
+                """;
+        var client = """
+                package cinneide;
+                public class ClientAF {
+                    public ProductA createA() { return new ProductA(); }
+                    public ProductB createB() { return new ProductB(); }
+                }
+                """;
+        return new ArrayList<>(List.of(
+                JavaFile.builder().name("ProductA.java").path("cinneide/").originalClass(productA).parsed(AbstractSyntaxTree.parseSingle(productA)).build(),
+                JavaFile.builder().name("ProductB.java").path("cinneide/").originalClass(productB).parsed(AbstractSyntaxTree.parseSingle(productB)).build(),
+                JavaFile.builder().name("ClientAF.java").path("cinneide/").originalClass(client).parsed(AbstractSyntaxTree.parseSingle(client)).build()
+        ));
+    }
+
+    public static List<JavaFile> createStrategySample() {
+        var context = """
+                package cinneide;
+                public class PricingContext {
+                    public int percentage(int value) { return value / 10; }
+                    public int discount(int value) { return value - 5; }
+                }
+                """;
+        return new ArrayList<>(List.of(
+                JavaFile.builder().name("PricingContext.java").path("cinneide/").originalClass(context).parsed(AbstractSyntaxTree.parseSingle(context)).build()
+        ));
+    }
+
+    public static List<JavaFile> createBridgeSample() {
+        var iface = """
+                package cinneide;
+                public interface Implementor {
+                    String op();
+                }
+                """;
+        var impl = """
+                package cinneide;
+                public class ConcreteImplementor implements Implementor {
+                    public String op() { return "ok"; }
+                }
+                """;
+        var client = """
+                package cinneide;
+                public class BridgeClient {
+                    public Implementor build() { return new ConcreteImplementor(); }
+                }
+                """;
+        return new ArrayList<>(List.of(
+                JavaFile.builder().name("Implementor.java").path("cinneide/").originalClass(iface).parsed(AbstractSyntaxTree.parseSingle(iface)).build(),
+                JavaFile.builder().name("ConcreteImplementor.java").path("cinneide/").originalClass(impl).parsed(AbstractSyntaxTree.parseSingle(impl)).build(),
+                JavaFile.builder().name("BridgeClient.java").path("cinneide/").originalClass(client).parsed(AbstractSyntaxTree.parseSingle(client)).build()
+        ));
+    }
+}

--- a/metrics-calculator/src/main/java/br/com/magnus/metricscalculator/repository/ExtractProjects.java
+++ b/metrics-calculator/src/main/java/br/com/magnus/metricscalculator/repository/ExtractProjects.java
@@ -8,10 +8,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
-import java.io.File;
-import java.io.FileWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 @Slf4j
 @Component
@@ -25,24 +25,31 @@ public class ExtractProjects {
         Assert.notNull(bucket, "Bucket cannot be null");
 
         var files = fileExtractor.extract(bucket, id);
-        var basePath = Files.createTempDirectory(id).toAbsolutePath();
-        files.forEach(file -> createTempFile(basePath.toString(), file));
+        var basePath = Files.createTempDirectory("project-").toAbsolutePath().normalize();
+        files.forEach(file -> createTempFile(basePath, file));
 
         return basePath;
     }
 
     @SneakyThrows
-    private void createTempFile(String basePath, JavaFile javaFile) {
+    private void createTempFile(Path basePath, JavaFile javaFile) {
+        Assert.notNull(javaFile, "Java file cannot be null");
         Assert.notNull(javaFile.getName(), "Name cannot be null");
+        Assert.notNull(javaFile.getPath(), "Path cannot be null");
         Assert.notNull(javaFile.getOriginalClass(), "Original class cannot be null");
 
-        var file = new File(basePath + "/" + javaFile.getFullName());
-        file.getParentFile().mkdirs();
-        file.createNewFile();
-        try (var fileWriter = new FileWriter(file)) {
-            fileWriter.write(javaFile.getOriginalClass());
-        } catch (Exception e) {
-           log.error("Erro to Read File", e);
+        var safePath = resolveInsideBasePath(basePath, javaFile.getPath(), javaFile.getName());
+        Files.createDirectories(safePath.getParent());
+        Files.writeString(safePath, javaFile.getOriginalClass(), StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    private Path resolveInsideBasePath(Path basePath, String relativePath, String fileName) {
+        var normalizedRelativePath = relativePath.replace("\\", "/");
+        var normalizedName = fileName.replace("\\", "/");
+        var candidate = basePath.resolve(normalizedRelativePath).resolve(normalizedName).normalize();
+        if (!candidate.startsWith(basePath)) {
+            throw new IllegalArgumentException("Invalid file path");
         }
+        return candidate;
     }
 }

--- a/metrics-calculator/src/main/java/br/com/magnus/metricscalculator/repository/ExtractProjects.java
+++ b/metrics-calculator/src/main/java/br/com/magnus/metricscalculator/repository/ExtractProjects.java
@@ -38,7 +38,7 @@ public class ExtractProjects {
         Assert.notNull(javaFile.getPath(), "Path cannot be null");
         Assert.notNull(javaFile.getOriginalClass(), "Original class cannot be null");
 
-        var safePath = resolveInsideBasePath(basePath, javaFile.getPath(), javaFile.getName());
+        var safePath = resolveInsideBasePath(basePath, javaFile.getPath(), javaFile.getName().toString());
         Files.createDirectories(safePath.getParent());
         Files.writeString(safePath, javaFile.getOriginalClass(), StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
     }

--- a/metrics-calculator/src/test/java/br/com/magnus/metricscalculator/extraction/ExtractProjectsTest.java
+++ b/metrics-calculator/src/test/java/br/com/magnus/metricscalculator/extraction/ExtractProjectsTest.java
@@ -108,4 +108,20 @@ class ExtractProjectsTest {
 
         assertEquals("Original class cannot be null", exception.getMessage());
     }
+
+    @Test
+    @DisplayName("Throws IllegalArgumentException when JavaFile path tries directory traversal")
+    void shouldThrowExceptionWhenJavaFilePathHasTraversal() {
+        when(fileExtractor.extract(anyString(), anyString()))
+                .thenReturn(Collections.singletonList(JavaFile.builder()
+                        .name("Test.java")
+                        .originalClass("public class Test {}")
+                        .path("../../../../tmp/")
+                        .build()));
+
+        var exception = assertThrows(IllegalArgumentException.class,
+                () -> extractProjects.extractProject("id", "bucket"));
+
+        assertEquals("Invalid file path", exception.getMessage());
+    }
 }


### PR DESCRIPTION
## Summary
- implement Cinneide transformation tool in `detection-and-refactoring` with mini-transformations and composed pattern methods
- add unit and integration tests for Cinneide flows
- harden extraction path handling in `metrics-calculator` `ExtractProjects` to block directory traversal
- align `JavaFile#getName` signature to `public Object getName()` and update typed call sites
- update README with Cinneide methods/reference and add a draw.io architecture diagram

## Cinneide implementation
- mini-transformations: `ABSTRACTION`, `ENCAPSULATE_CONSTRUCTION`, `ABSTRACT_ACCESS`, `PARTIAL_ABSTRACTION`, `DELEGATION`, `WRAPPER`
- composed methods: `applyFactoryMethod`, `applySingleton`, `applyAbstractFactory`, `applyStrategy`, `applyBridge`
- safety/idempotency improvements for generated classes and method signatures

## Security
- `ExtractProjects` now resolves and normalizes file paths, rejecting traversal outside extraction root (`Invalid file path`)
- added traversal-focused test coverage in `ExtractProjectsTest`

## Documentation
- Added draw.io diagram source at `docs/tool-flow.drawio`
- README now includes "Tool Diagram (draw.io)" section

## Validation
- `mvn -B test -pl config-starter`
- `mvn -B test -pl metrics-calculator`
- `mvn -B test -pl detection-and-refactoring`
